### PR TITLE
examples: add a row_major example

### DIFF
--- a/examples/row-major.shader_test
+++ b/examples/row-major.shader_test
@@ -1,0 +1,30 @@
+[vertex shader passthrough]
+
+[fragment shader]
+#version 430
+
+layout (location = 0) out vec4 color_out;
+layout (binding = 5) uniform block {
+  layout(row_major) mat3x4 m;
+};
+
+void main()
+{
+   color_out = m[0] + m[1] + m[2];
+}
+
+
+[test]
+clear
+
+# The shader uses a mat3x4 that it is specified on row_major
+# layout. So we need to manually re-sort it here when specify the
+# data.
+uniform ubo 5 vec3 0  0.11 0.21 0.31
+uniform ubo 5 vec3 16 0.12 0.22 0.32
+uniform ubo 5 vec3 32 0.13 0.23 0.33
+uniform ubo 5 vec3 48 0.14 0.24 0.34
+
+draw rect -1 -1 2 2
+
+probe all rgba 0.63 0.66 0.69 0.72


### PR DESCRIPTION
When using the following line to specify matrix data:
   uniform ubo 3 mat2 16 0.0 1.0 1.0 0.0

It is assumed that the data is in the default column major mode. On
piglit, you can add a lot of info about the data, included if it is
row_major, so shader_runner would re-order the data for you.

With vkrunner you could do the same in one line with mat2 and
mat3. With mat3x4 you need to take into account the stride. As
vkrunner allows to specify the data in a more flexible way (no need to
use the shader type, that is just used to parse and push the data), it
is more pragmatic to workaround the issue by specifying the
individual columns as vec3.