### PR TITLE
Add descriptor set option to buffer resource

### DIFF
--- a/examples/desc_set_and_binding.shader_test
+++ b/examples/desc_set_and_binding.shader_test
@@ -1,0 +1,161 @@
+[require]
+fragmentStoresAndAtomics
+
+[vertex shader passthrough]
+
+[fragment shader]
+#version 450
+
+layout(location = 0) out vec4 color_out;
+
+layout(binding = 3) buffer block {
+        vec4 color_in;
+        vec3 triangle;
+        uint three;
+};
+
+layout(binding = 4) buffer block0 {
+        vec4 set0_binding4;
+        vec4 set0_binding4_result;
+};
+
+layout(set = 0, binding = 5) buffer block1 {
+        vec4 set0_binding5;
+        vec4 set0_binding5_result;
+};
+
+layout(set = 1, binding = 3) buffer block2 {
+        vec4 set1_binding3;
+        vec4 set1_binding3_result;
+};
+
+layout(set = 1, binding = 5) buffer block3 {
+        vec4 set1_binding5;
+        vec4 set1_binding5_result;
+};
+
+layout(set = 1, binding = 6) buffer block4 {
+        vec4 set1_binding6;
+        vec4 set1_binding6_result;
+};
+
+layout(set = 2, binding = 0) buffer block5 {
+        vec4 set2_binding0;
+        vec4 set2_binding0_result;
+};
+
+layout(set = 2, binding = 3) buffer block6 {
+        vec4 set2_binding3;
+        vec4 set2_binding3_result;
+};
+
+layout(set = 2, binding = 4) buffer block7 {
+        vec4 set2_binding4;
+        vec4 set2_binding4_result;
+};
+
+layout(set = 2, binding = 7) buffer block8 {
+        vec4 set2_binding7;
+        vec4 set2_binding7_result;
+};
+
+layout(set = 3, binding = 2) uniform block9 {
+        vec4 ubo_set3_binding2;
+};
+
+layout(set = 3, binding = 6) uniform block10 {
+        vec4 ubo_set3_binding6;
+};
+
+layout(set = 3, binding = 10) uniform block11 {
+        vec4 ubo_set3_binding10;
+};
+
+void
+main()
+{
+        // Descriptor set and binding test
+        set2_binding7_result = set0_binding4;
+        set0_binding4_result = set0_binding5;
+        set0_binding5_result = set1_binding3;
+        set1_binding3_result = set1_binding5 + ubo_set3_binding2;
+        set1_binding5_result = set1_binding6;
+        set1_binding6_result = set2_binding0;
+        set2_binding0_result = set2_binding3 + ubo_set3_binding6;
+        set2_binding3_result = set2_binding4 + ubo_set3_binding10;
+        set2_binding4_result = set2_binding7;
+
+        color_out = color_in;
+        three = 3;
+        triangle = vec3(3, 4, 5);
+}
+
+[test]
+clear
+
+# Set color_in
+ssbo 3 subdata vec4 0 0.0 1.0 0.0 1.0
+
+# Clear other values
+ssbo 3 subdata vec3 16 0.0 0.0 0.0
+ssbo 3 subdata uint 28 0
+
+# Descriptor set and binding test
+ssbo 0:4 subdata vec4 0 0.4 0.4 0.4 0.4
+ssbo 5 subdata vec4 0 0.5 0.5 0.5 0.5
+ssbo 1:3 subdata vec4 0 1.3 1.3 1.3 1.3
+ssbo 1:5 subdata vec4 0 1.5 1.5 1.5 1.5
+ssbo 1:6 subdata vec4 0 1.6 1.6 1.6 1.6
+ssbo 2:0 subdata vec4 0 2.0 2.0 2.0 2.0
+ssbo 2:3 subdata vec4 0 2.3 2.3 2.3 2.3
+ssbo 2:4 subdata vec4 0 2.4 2.4 2.4 2.4
+ssbo 2:7 subdata vec4 0 2.7 2.7 2.7 2.7
+
+ssbo 0:4 subdata vec4 16 0.4 0.4 0.4 0.4
+ssbo 5 subdata vec4 16 0.5 0.5 0.5 0.5
+ssbo 1:3 subdata vec4 16 1.3 1.3 1.3 1.3
+ssbo 1:5 subdata vec4 16 1.5 1.5 1.5 1.5
+ssbo 1:6 subdata vec4 16 1.6 1.6 1.6 1.6
+ssbo 2:0 subdata vec4 16 2.0 2.0 2.0 2.0
+ssbo 2:3 subdata vec4 16 2.3 2.3 2.3 2.3
+ssbo 2:4 subdata vec4 16 2.4 2.4 2.4 2.4
+ssbo 2:7 subdata vec4 16 2.7 2.7 2.7 2.7
+
+uniform ubo 3:2 vec4 0 0.1 0.2 0.3 0.4
+uniform ubo 3:6 vec4 0 0.2 0.4 0.6 0.8
+uniform ubo 3:10 vec4 0 -0.1 -0.2 -0.3 -0.4
+
+
+draw rect -1 -1 2 2
+
+# Probe the buffer to make sure that reading the SSBO worked
+probe all rgba 0.0 1.0 0.0 1.0
+
+# Probe the SSBO to check that writing worked
+probe ssbo vec3 3 16 == 3 4 5
+probe ssbo uint 3 28 < 4
+probe ssbo uint 3 28 == 3
+
+# Descriptor set and binding test
+#
+# Note that floating point values might not be exactly same
+# and we allow small errors i.e., 0.000001
+#
+probe ssbo vec4 4   16 >  0.499999 0.499999 0.499999 0.499999
+probe ssbo vec4 4   16 <  0.500001 0.500001 0.500001 0.500001
+probe ssbo vec4 0:5 16 >  1.299999 1.299999 1.299999 1.299999
+probe ssbo vec4 0:5 16 <  1.300001 1.300001 1.300001 1.300001
+probe ssbo vec4 1:3 16 >  1.599999 1.699999 1.799999 1.899999
+probe ssbo vec4 1:3 16 <  1.600001 1.700001 1.800001 1.900001
+probe ssbo vec4 1:5 16 >  1.599999 1.599999 1.599999 1.599999
+probe ssbo vec4 1:5 16 <  1.600001 1.600001 1.600001 1.600001
+probe ssbo vec4 1:6 16 >  1.999999 1.999999 1.999999 1.999999
+probe ssbo vec4 1:6 16 <  2.000001 2.000001 2.000001 2.000001
+probe ssbo vec4 2:0 16 >  2.499999 2.699999 2.899999 3.099999
+probe ssbo vec4 2:0 16 <  2.500001 2.700001 2.900001 3.100001
+probe ssbo vec4 2:3 16 >  2.299999 2.199999 2.099999 1.999999
+probe ssbo vec4 2:3 16 <  2.300001 2.200001 2.100001 2.000001
+probe ssbo vec4 2:4 16 >  2.699999 2.699999 2.699999 2.699999
+probe ssbo vec4 2:4 16 <  2.700001 2.700001 2.700001 2.700001
+probe ssbo vec4 2:7 16 >  0.399999 0.399999 0.399999 0.399999
+probe ssbo vec4 2:7 16 <  0.400001 0.400001 0.400001 0.400001

--- a/vkrunner/vr-context.c
+++ b/vkrunner/vr-context.c
@@ -373,38 +373,6 @@ init_vk(struct vr_context *context)
                 goto error;
         }
 
-        VkDescriptorPoolSize pool_sizes[] = {
-                {
-                        .type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                        .descriptorCount = 4
-                },
-                {
-                        .type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-                        .descriptorCount = 4
-                },
-                {
-                        .type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-                        .descriptorCount = 4
-                },
-        };
-        VkDescriptorPoolCreateInfo descriptor_pool_create_info = {
-                .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
-                .flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,
-                .maxSets = 4,
-                .poolSizeCount = VR_N_ELEMENTS(pool_sizes),
-                .pPoolSizes = pool_sizes
-        };
-        res = vkfn->vkCreateDescriptorPool(context->device,
-                                           &descriptor_pool_create_info,
-                                           NULL, /* allocator */
-                                           &context->descriptor_pool);
-        if (res != VK_SUCCESS) {
-                vr_error_message(context->config,
-                                 "Error creating VkDescriptorPool");
-                vres = VR_RESULT_FAIL;
-                goto error;
-        }
-
         VkFenceCreateInfo fence_create_info = {
                 .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO
         };

--- a/vkrunner/vr-pipeline.h
+++ b/vkrunner/vr-pipeline.h
@@ -34,7 +34,9 @@
 struct vr_pipeline {
         struct vr_window *window;
         VkPipelineLayout layout;
-        VkDescriptorSetLayout descriptor_set_layout;
+        VkDescriptorSetLayout *descriptor_set_layout;
+        unsigned *desc_sets;
+        unsigned n_desc_sets;
         int n_pipelines;
         VkPipeline *pipelines;
         VkPipelineCache pipeline_cache;

--- a/vkrunner/vr-script.h
+++ b/vkrunner/vr-script.h
@@ -91,6 +91,7 @@ struct vr_script_command {
                 } probe_rect;
 
                 struct {
+                        unsigned desc_set;
                         unsigned binding;
                         enum vr_box_comparison comparison;
                         size_t offset;
@@ -98,6 +99,7 @@ struct vr_script_command {
                 } probe_ssbo;
 
                 struct {
+                        unsigned desc_set;
                         unsigned binding;
                         size_t offset;
                         size_t size;
@@ -134,6 +136,7 @@ enum vr_script_buffer_type {
 };
 
 struct vr_script_buffer {
+        unsigned desc_set;
         unsigned binding;
         enum vr_script_buffer_type type;
         size_t size;


### PR DESCRIPTION
As a part of ideas discussed in #10 , this pull request enables setting descriptor sets for buffer resources.
The new code allows both `(ssbo|uniform ubo|probe ssbo [type]) [descriptor set]:[binding]` and `(ssbo|uniform ubo|probe ssbo [type]) [binding]`. If specified, the descriptor set must be a non-negative integer (>= 0). If it is not specified, the default descriptor set is 0 and it will be used.