### PR TITLE
Allow error bounds for expected output

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -45,6 +45,7 @@ VKRUNNER_SRC_FILES := vkrunner/vr-allocate-store.c \
 	vkrunner/vr-subprocess.c \
 	vkrunner/vr-temp-file.c \
 	vkrunner/vr-test.c \
+	vkrunner/vr-tolerance.c \
 	vkrunner/vr-util.c \
 	vkrunner/vr-vbo.c \
 	vkrunner/vr-vk.c \

--- a/README.md
+++ b/README.md
@@ -120,9 +120,32 @@ the largest offset.
 > probe ssbo _type_ _binding_ _offset_ _comparison_ _values_…
 
 Probes a value in the storage buffer at _binding_. The _comparison_
-can be one of `==`, `!=`, `<`, `>=`, `>` or `<=`. If the type has more
-than one component then they are compared individually until one of
-them fails the comparison.
+can be one of `==`, `!=`, `<`, `>=`, `>`, `<=` or `~=`. If the type
+has more than one component then they are compared individually until
+one of them fails the comparison. `~=` is the same with `==` but `~=`
+allows errors for `double` or `float` type numbers while `==` does
+not. Allowed errors can be set by the following `tolerance` command.
+See [examples/tolerance.shader_test](examples/tolerance.shader_test)
+for the usage of `~=`.
+
+> tolerance _tolerance0 tolerance1 tolerance2 tolerance3_
+
+Sets four tolerances i.e., allowed errors. `vecN` type values will
+use first `N` tolerances among those four. Each column of `matMxN` type
+values will also use first `N` tolerances. `float` and `double` type
+values will use only the first tolerance. Each tolerance value can be
+an `double` type real number or percentage e.g., `0.01%`. `tolerance`
+command can be also used for comparisons of pixels. See
+[examples/tolerance.shader_test]( examples/tolerance.shader_test) for
+the usage of `tolerance` command.
+
+> tolerance _tolerance0_
+
+Sets a tolerance i.e., an allowed error. If this command is set, all
+components of `vecN` and `matMxN` type values will use the same
+tolerance. Each tolerance value can be an `double` type real number or
+percentage e.g., `0.01%`. See [examples/tolerance.shader_test](
+examples/tolerance.shader_test) for the usage of `tolerance` command.
 
 > clear color _r_ _g_ _b_ _a_
 

--- a/examples/desc_set_and_binding.shader_test
+++ b/examples/desc_set_and_binding.shader_test
@@ -141,21 +141,13 @@ probe ssbo uint 3 28 == 3
 # Note that floating point values might not be exactly same
 # and we allow small errors i.e., 0.000001
 #
-probe ssbo vec4 4   16 >  0.499999 0.499999 0.499999 0.499999
-probe ssbo vec4 4   16 <  0.500001 0.500001 0.500001 0.500001
-probe ssbo vec4 0:5 16 >  1.299999 1.299999 1.299999 1.299999
-probe ssbo vec4 0:5 16 <  1.300001 1.300001 1.300001 1.300001
-probe ssbo vec4 1:3 16 >  1.599999 1.699999 1.799999 1.899999
-probe ssbo vec4 1:3 16 <  1.600001 1.700001 1.800001 1.900001
-probe ssbo vec4 1:5 16 >  1.599999 1.599999 1.599999 1.599999
-probe ssbo vec4 1:5 16 <  1.600001 1.600001 1.600001 1.600001
-probe ssbo vec4 1:6 16 >  1.999999 1.999999 1.999999 1.999999
-probe ssbo vec4 1:6 16 <  2.000001 2.000001 2.000001 2.000001
-probe ssbo vec4 2:0 16 >  2.499999 2.699999 2.899999 3.099999
-probe ssbo vec4 2:0 16 <  2.500001 2.700001 2.900001 3.100001
-probe ssbo vec4 2:3 16 >  2.299999 2.199999 2.099999 1.999999
-probe ssbo vec4 2:3 16 <  2.300001 2.200001 2.100001 2.000001
-probe ssbo vec4 2:4 16 >  2.699999 2.699999 2.699999 2.699999
-probe ssbo vec4 2:4 16 <  2.700001 2.700001 2.700001 2.700001
-probe ssbo vec4 2:7 16 >  0.399999 0.399999 0.399999 0.399999
-probe ssbo vec4 2:7 16 <  0.400001 0.400001 0.400001 0.400001
+tolerance 0.00001
+probe ssbo vec4 4   16 ~=  0.5 0.5 0.5 0.5
+probe ssbo vec4 0:5 16 ~=  1.3 1.3 1.3 1.3
+probe ssbo vec4 1:3 16 ~=  1.6 1.7 1.8 1.9
+probe ssbo vec4 1:5 16 ~=  1.6 1.6 1.6 1.6
+probe ssbo vec4 1:6 16 ~=  2.0 2.0 2.0 2.0
+probe ssbo vec4 2:0 16 ~=  2.5 2.7 2.9 3.1
+probe ssbo vec4 2:3 16 ~=  2.3 2.2 2.1 2.0
+probe ssbo vec4 2:4 16 ~=  2.7 2.7 2.7 2.7
+probe ssbo vec4 2:7 16 ~=  0.4 0.4 0.4 0.4

--- a/examples/tolerance.shader_test
+++ b/examples/tolerance.shader_test
@@ -1,0 +1,58 @@
+[require]
+fragmentStoresAndAtomics
+framebuffer R32G32B32A32_SFLOAT
+
+[vertex shader passthrough]
+
+[fragment shader]
+#version 430
+
+layout(location = 0) out vec4 color_out;
+
+layout(binding = 4) buffer block0 {
+        vec4 set0_binding4;
+        vec4 set0_binding4_result;
+};
+
+layout(set = 0, binding = 5) buffer block1 {
+        vec4 set0_binding5;
+        vec4 set0_binding5_result;
+};
+
+void
+main()
+{
+        // Descriptor set and binding test
+        set0_binding4_result = set0_binding5;
+        set0_binding5_result = set0_binding4;
+
+        color_out = vec4(atan(0.0, -1.0),
+                     42.0,
+                     length(vec2(1.0, 1.0)),
+                     fma(2.0, 3.0, 1.0));
+}
+
+[test]
+clear
+
+# Descriptor set and binding test
+ssbo 0:4 subdata vec4 0 0.4 0.4 0.4 0.4
+ssbo 5 subdata vec4 0 0.5 0.5 0.5 0.5
+ssbo 0:4 subdata vec4 16 0.4 0.4 0.4 0.4
+ssbo 5 subdata vec4 16 0.5 0.5 0.5 0.5
+
+draw rect -1 -1 2 2
+
+tolerance 0.01% 0.01% 0.01% 0.01%
+probe all rgba 3.141592653589793 42.0 1.4142135623730951 7.0
+
+tolerance 0.01% 0.001% 0.0001% 0.00001%
+probe all rgba 3.141592653589793 42.0 1.4142135623730951 7.0
+
+tolerance 0.00001
+probe ssbo vec4 4   16 ~= 0.5 0.5 0.5 0.5
+probe ssbo vec4 4   16 ~= 0.500002 0.500002 0.500002 0.500002
+probe ssbo vec4 4   16 ~= 0.499999 0.499999 0.499999 0.499999
+
+tolerance 0.001%
+probe ssbo vec4 0:5 16 ~= 0.4 0.4 0.4 0.4

--- a/vkrunner/CMakeLists.txt
+++ b/vkrunner/CMakeLists.txt
@@ -62,6 +62,8 @@ set(VKRUNNER_SOURCE_FILES
         vr-subprocess.h
         vr-test.c
         vr-test.h
+        vr-tolerance.c
+        vr-tolerance.h
         vr-vbo.c
         vr-vbo.h
         vr-window.c

--- a/vkrunner/vr-box.h
+++ b/vkrunner/vr-box.h
@@ -30,6 +30,8 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+#include "vr-tolerance.h"
+
 enum vr_box_type {
         VR_BOX_TYPE_INT,
         VR_BOX_TYPE_UINT,
@@ -106,6 +108,7 @@ enum vr_box_base_type {
 
 enum vr_box_comparison {
         VR_BOX_COMPARISON_EQUAL,
+        VR_BOX_COMPARISON_FUZZY_EQUAL,
         VR_BOX_COMPARISON_NOT_EQUAL,
         VR_BOX_COMPARISON_LESS,
         VR_BOX_COMPARISON_GREATER_EQUAL,
@@ -162,6 +165,7 @@ vr_box_for_each_component(enum vr_box_type type,
 
 bool
 vr_box_compare(enum vr_box_comparison comparison,
+               const struct vr_tolerance *tolerance,
                const struct vr_box *a,
                const struct vr_box *b);
 

--- a/vkrunner/vr-script.h
+++ b/vkrunner/vr-script.h
@@ -35,6 +35,7 @@
 #include "vr-box.h"
 #include "vr-source.h"
 #include "vr-shader-stage.h"
+#include "vr-tolerance.h"
 
 enum vr_script_op {
         VR_SCRIPT_OP_DRAW_RECT,
@@ -79,6 +80,7 @@ struct vr_script_command {
                         int n_components;
                         int x, y, w, h;
                         double color[4];
+                        struct vr_tolerance tolerance;
                 } probe_rect;
 
                 struct {
@@ -87,6 +89,7 @@ struct vr_script_command {
                         enum vr_box_comparison comparison;
                         size_t offset;
                         struct vr_box value;
+                        struct vr_tolerance tolerance;
                 } probe_ssbo;
 
                 struct {

--- a/vkrunner/vr-tolerance.c
+++ b/vkrunner/vr-tolerance.c
@@ -1,0 +1,46 @@
+/*
+ * vkrunner
+ *
+ * Copyright (C) 2018 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "config.h"
+
+#include <math.h>
+
+#include "vr-tolerance.h"
+
+bool
+vr_tolerance_equal(const struct vr_tolerance *tolerance,
+                   int component,
+                   const double a,
+                   const double b)
+{
+        if (tolerance->is_percent) {
+                if (fabs(a - b) > fabs(tolerance->value[component] / 100.0 * b))
+                        return false;
+        } else {
+                if (fabs(a - b) > tolerance->value[component])
+                        return false;
+        }
+        return true;
+}

--- a/vkrunner/vr-tolerance.h
+++ b/vkrunner/vr-tolerance.h
@@ -1,0 +1,42 @@
+/*
+ * vkrunner
+ *
+ * Copyright (C) 2018 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef VR_TOLERANCE_H
+#define VR_TOLERANCE_H
+
+#include <stdbool.h>
+
+struct vr_tolerance {
+        double value[4];
+        bool is_percent;
+};
+
+bool
+vr_tolerance_equal(const struct vr_tolerance *tolerance,
+                   int component,
+                   const double a,
+                   const double b);
+
+#endif /* VR_TOLERANCE_H */


### PR DESCRIPTION
Add "tolerance" command to set up the error bound and support
fuzzy equality operator "~=". The fuzzy equality can only be used
for comparisions of float values.

EXAMPLE: examples/tolerance.shader_test
RELATED ISSUE: #23