### PR TITLE
Allow probing multiple values of an SSBO with a single command

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ one of them fails the comparison. `~=` is the same with `==` but `~=`
 allows errors for `double` or `float` type numbers while `==` does
 not. Allowed errors can be set by the following `tolerance` command.
 See [examples/tolerance.shader_test](examples/tolerance.shader_test)
-for the usage of `~=`.
+for the usage of `~=`. Multiple values can be listed to compare an
+array of values. In that case the buffer is assumed to have std140
+layout.
 
 > tolerance _tolerance0 tolerance1 tolerance2 tolerance3_
 

--- a/examples/ssbo.shader_test
+++ b/examples/ssbo.shader_test
@@ -8,9 +8,10 @@ fragmentStoresAndAtomics
 
 layout(location = 0) out vec4 color_out;
 
-layout(binding = 3) buffer block {
+layout(binding = 3, std140) buffer block {
         vec4 color_in;
         vec3 triangle;
+        vec2 fib[2];
         uint three;
 };
 
@@ -20,6 +21,8 @@ main()
         color_out = color_in;
         three = 3;
         triangle = vec3(3, 4, 5);
+        fib[0] = vec2(1, 1);
+        fib[1] = vec2(2, 3);
 }
 
 [test]
@@ -30,7 +33,8 @@ ssbo 3 subdata vec4 0 0.0 1.0 0.0 1.0
 
 # Clear other values
 ssbo 3 subdata vec3 16 0.0 0.0 0.0
-ssbo 3 subdata uint 28 0
+ssbo 3 subdata vec2 32 0.0 0.0 0.0 0.0
+ssbo 3 subdata uint 64 0
 
 draw rect -1 -1 2 2
 
@@ -39,5 +43,8 @@ probe all rgba 0.0 1.0 0.0 1.0
 
 # Probe the SSBO to check that writing worked
 probe ssbo vec3 3 16 == 3 4 5
-probe ssbo uint 3 28 < 4
-probe ssbo uint 3 28 == 3
+probe ssbo uint 3 64 < 4
+probe ssbo uint 3 64 == 3
+
+# Multiple values of an array can be compared with a single command
+probe ssbo vec2 3 32 == 1 1 2 3

--- a/vkrunner/vr-box.h
+++ b/vkrunner/vr-box.h
@@ -116,34 +116,6 @@ enum vr_box_comparison {
         VR_BOX_COMPARISON_LESS_EQUAL
 };
 
-struct vr_box {
-        enum vr_box_type type;
-        union {
-                int i;
-                unsigned u;
-                int8_t i8;
-                uint8_t u8;
-                int16_t i16;
-                uint16_t u16;
-                int64_t i64;
-                uint64_t u64;
-                float f;
-                double d;
-                float vec[4];
-                double dvec[4];
-                int ivec[4];
-                unsigned uvec[4];
-                int8_t i8vec[4];
-                uint8_t u8vec[4];
-                int16_t i16vec[4];
-                uint16_t u16vec[4];
-                int64_t i64vec[4];
-                uint64_t u64vec[4];
-                float mat[16];
-                double dmat[16];
-        };
-};
-
 struct vr_box_type_info {
         enum vr_box_base_type base_type;
         int columns;
@@ -166,8 +138,9 @@ vr_box_for_each_component(enum vr_box_type type,
 bool
 vr_box_compare(enum vr_box_comparison comparison,
                const struct vr_tolerance *tolerance,
-               const struct vr_box *a,
-               const struct vr_box *b);
+               enum vr_box_type type,
+               const void *a,
+               const void *b);
 
 size_t
 vr_box_base_type_size(enum vr_box_base_type type);

--- a/vkrunner/vr-script.h
+++ b/vkrunner/vr-script.h
@@ -89,6 +89,7 @@ struct vr_script_command {
                         enum vr_box_comparison comparison;
                         size_t offset;
                         enum vr_box_type type;
+                        size_t n_values;
                         void *value;
                         struct vr_tolerance tolerance;
                 } probe_ssbo;

--- a/vkrunner/vr-script.h
+++ b/vkrunner/vr-script.h
@@ -88,7 +88,8 @@ struct vr_script_command {
                         unsigned binding;
                         enum vr_box_comparison comparison;
                         size_t offset;
-                        struct vr_box value;
+                        enum vr_box_type type;
+                        void *value;
                         struct vr_tolerance tolerance;
                 } probe_ssbo;
 


### PR DESCRIPTION
For example you can now probe vec2[2] with a command like:

    probe ssbo vec2 3 32 == 1 1 2 3
