### PR TITLE
Use strtod_l to parse doubles and floats

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -43,6 +43,7 @@ VKRUNNER_SRC_FILES := vkrunner/vr-allocate-store.c \
 	vkrunner/vr-script.c \
 	vkrunner/vr-source.c \
 	vkrunner/vr-stream.c \
+	vkrunner/vr-strtof.c \
 	vkrunner/vr-subprocess.c \
 	vkrunner/vr-temp-file.c \
 	vkrunner/vr-test.c \

--- a/vkrunner/CMakeLists.txt
+++ b/vkrunner/CMakeLists.txt
@@ -49,6 +49,8 @@ set(VKRUNNER_SOURCE_FILES
         vr-source.c
         vr-stream.c
         vr-stream.h
+        vr-strtof.c
+        vr-strtof.h
         vr-temp-file.c
         vr-temp-file.h
         vr-util.c

--- a/vkrunner/vr-executor.c
+++ b/vkrunner/vr-executor.c
@@ -169,6 +169,8 @@ vr_executor_new(void)
 {
         struct vr_executor *executor = vr_calloc(sizeof *executor);
 
+        vr_strtof_init(&executor->config.strtof_data);
+
         return executor;
 }
 
@@ -317,6 +319,8 @@ void
 vr_executor_free(struct vr_executor *executor)
 {
         free_context(executor);
+
+        vr_strtof_destroy(&executor->config.strtof_data);
 
         vr_free(executor);
 }

--- a/vkrunner/vr-hex.c
+++ b/vkrunner/vr-hex.c
@@ -37,7 +37,9 @@
  * pattern to generate a float value.
  */
 float
-vr_hex_strtof(const char *nptr, char **endptr)
+vr_hex_strtof(const struct vr_strtof_data *data,
+              const char *nptr,
+              char **endptr)
 {
         /* skip spaces and tabs */
         while (*nptr == ' ' || *nptr == '\t')
@@ -52,7 +54,7 @@ vr_hex_strtof(const char *nptr, char **endptr)
                 x.u = strtoul(nptr, endptr, 16);
                 return x.f;
         } else {
-                return strtod(nptr, endptr);
+                return vr_strtod(data, nptr, endptr);
         }
 }
 
@@ -61,7 +63,9 @@ vr_hex_strtof(const char *nptr, char **endptr)
  * pattern to generate a double value.
  */
 double
-vr_hex_strtod(const char *nptr, char **endptr)
+vr_hex_strtod(const struct vr_strtof_data *data,
+              const char *nptr,
+              char **endptr)
 {
         /* skip spaces and tabs */
         while (*nptr == ' ' || *nptr == '\t')
@@ -76,7 +80,7 @@ vr_hex_strtod(const char *nptr, char **endptr)
                 x.u64 = strtoull(nptr, endptr, 16);
                 return x.d;
         } else {
-                return strtod(nptr, endptr);
+                return vr_strtod(data, nptr, endptr);
         }
 }
 
@@ -85,7 +89,9 @@ vr_hex_strtod(const char *nptr, char **endptr)
  * generate a signed int value.
  */
 int
-vr_hex_strtol(const char *nptr, char **endptr)
+vr_hex_strtol(const struct vr_strtof_data *data,
+              const char *nptr,
+              char **endptr)
 {
         /* skip spaces and tabs */
         while (*nptr == ' ' || *nptr == '\t')
@@ -109,7 +115,9 @@ vr_hex_strtol(const char *nptr, char **endptr)
  * hex bit pattern to generate a half float value.
  */
 uint16_t
-vr_hex_strtohf(const char *nptr, char **endptr)
+vr_hex_strtohf(const struct vr_strtof_data *data,
+               const char *nptr,
+               char **endptr)
 {
         /* skip spaces and tabs */
         while (*nptr == ' ' || *nptr == '\t')
@@ -124,6 +132,6 @@ vr_hex_strtohf(const char *nptr, char **endptr)
                         return u;
                 }
         } else {
-                return vr_half_float_from_float(strtod(nptr, endptr));
+                return vr_half_float_from_float(vr_strtod(data, nptr, endptr));
         }
 }

--- a/vkrunner/vr-hex.h
+++ b/vkrunner/vr-hex.h
@@ -25,17 +25,26 @@
 #define VR_HEX_H
 
 #include <stdint.h>
+#include "vr-strtof.h"
 
 float
-vr_hex_strtof(const char *nptr, char **endptr);
+vr_hex_strtof(const struct vr_strtof_data *data,
+              const char *nptr,
+              char **endptr);
 
 double
-vr_hex_strtod(const char *nptr, char **endptr);
+vr_hex_strtod(const struct vr_strtof_data *data,
+              const char *nptr,
+              char **endptr);
 
 int
-vr_hex_strtol(const char *nptr, char **endptr);
+vr_hex_strtol(const struct vr_strtof_data *data,
+              const char *nptr,
+              char **endptr);
 
 uint16_t
-vr_hex_strtohf(const char *nptr, char **endptr);
+vr_hex_strtohf(const struct vr_strtof_data *data,
+               const char *nptr,
+               char **endptr);
 
 #endif /* VR_HEX_H */

--- a/vkrunner/vr-strtof.h
+++ b/vkrunner/vr-strtof.h
@@ -23,22 +23,37 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef VR_CONFIG_H
-#define VR_CONFIG_H
+#ifndef VR_STRTOF_H
+#define VR_STRTOF_H
 
-#include <stdbool.h>
-#include "vr-result.h"
-#include "vr-callback.h"
-#include "vr-strtof.h"
+#include <stdint.h>
 
-struct vr_config {
-        bool show_disassembly;
-
-        vr_callback_error error_cb;
-        vr_callback_inspect inspect_cb;
-        void *user_data;
-
-        struct vr_strtof_data strtof_data;
+/* This union has enough space to hold whatever locale_t is. We don’t
+ * want to actually use locale_t because we want to confine
+ * _GNU_SOURCE to vr-strtof.c so that we don’t accidentally break
+ * portability.
+ */
+struct vr_strtof_data {
+        union {
+                void *pointer;
+                uint64_t integer;
+        };
 };
 
-#endif /* VR_CONFIG_H */
+void
+vr_strtof_init(struct vr_strtof_data *data);
+
+float
+vr_strtof(const struct vr_strtof_data *data,
+          const char *nptr,
+          char **endptr);
+
+double
+vr_strtod(const struct vr_strtof_data *data,
+          const char *nptr,
+          char **endptr);
+
+void
+vr_strtof_destroy(struct vr_strtof_data *data);
+
+#endif /* VR_STRTOF_H */

--- a/vkrunner/vr-vbo.c
+++ b/vkrunner/vr-vbo.c
@@ -262,7 +262,10 @@ parse_datum(const struct vr_config *config,
         case VR_FORMAT_MODE_SFLOAT:
                 switch (bit_size) {
                 case 16: {
-                        unsigned short value = vr_hex_strtohf(*text, &endptr);
+                        unsigned short value =
+                                vr_hex_strtohf(&config->strtof_data,
+                                               *text,
+                                               &endptr);
                         if (errno == ERANGE) {
                                 vr_error_message(config,
                                                  "Could not parse as "
@@ -273,7 +276,9 @@ parse_datum(const struct vr_config *config,
                         goto handled;
                 }
                 case 32: {
-                        float value = vr_hex_strtof(*text, &endptr);
+                        float value = vr_hex_strtof(&config->strtof_data,
+                                                    *text,
+                                                    &endptr);
                         if (errno == ERANGE) {
                                 vr_error_message(config,
                                                  "Could not parse as float");
@@ -283,7 +288,9 @@ parse_datum(const struct vr_config *config,
                         goto handled;
                 }
                 case 64: {
-                        double value = vr_hex_strtod(*text, &endptr);
+                        double value = vr_hex_strtod(&config->strtof_data,
+                                                     *text,
+                                                     &endptr);
                         if (errno == ERANGE) {
                                 vr_error_message(config,
                                                  "Could not parse as double");


### PR DESCRIPTION
This fixes the problem that using strtod is locale-sensitive. This is also the approach that Mesa took to fix the same problem.

Fixes #34 