### PR TITLE
precompile-script.py: add arguments for glslangValidator and spirv-as

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,11 @@ test scripts to binary. It can be run for example as below:
     ./precompile-script.py -o compiled-examples examples/*.shader_test
     ./src/vkrunner compiled-examples/*.shader_test
 
+If glslangValidator and spirv-as are not in the path, you can indicate
+where the binaries are with the following command line arguments:
+
+    ./precompile-script.py -o compiled-examples examples/*.shader_test -g PATH_GLSLANG/glslangValidator -s PATH_SPIRV_AS/spirv-as
+
 ## Library
 
 VkRunner can alternatively be used as a library to integrate it into


### PR DESCRIPTION
Add two new arguments to precompile-script.py, they specify where the glslangValidator and spirv-as binaries are in the system, so the user doesn't need to add them to the current path nor install them into the system.

This change is going to be used later when precompile-script.py is called by CTS in order to prebuild SPIR-V binaries.