### PR TITLE
RFC: CTS integration without using binaries for precompiling shaders

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -42,6 +42,7 @@ struct string_array {
 
 struct main_data {
         struct vr_executor *executor;
+        struct vr_config *config;
         const char *image_filename;
         const char *buffer_filename;
         struct string_array filenames;
@@ -127,7 +128,7 @@ static bool
 opt_disassembly(struct main_data *data,
                 const char *arg)
 {
-        vr_executor_set_show_disassembly(data->executor, true);
+        vr_config_set_show_disassembly(data->config, true);
         return true;
 }
 
@@ -455,17 +456,18 @@ int
 main(int argc, char **argv)
 {
         int return_value = EXIT_SUCCESS;
-
+        struct vr_config *config = vr_config_new();
         struct main_data data = {
-                .executor = vr_executor_new(),
+                .executor = vr_executor_new(config),
+                .config = config,
                 .filenames = { .data = NULL },
                 .token_replacements = { .data = NULL },
                 .binding = -1,
                 .quiet = false
         };
 
-        vr_executor_set_user_data(data.executor, &data);
-        vr_executor_set_inspect_cb(data.executor, inspect_cb);
+        vr_config_set_user_data(config, &data);
+        vr_config_set_inspect_cb(config, inspect_cb);
 
         if (process_argv(&data, argc, argv)) {
                 enum vr_result result = run_scripts(&data);
@@ -484,6 +486,7 @@ main(int argc, char **argv)
                 return_value = EXIT_FAILURE;
         }
 
+        vr_config_free(config);
         vr_executor_free(data.executor);
         string_array_destroy(&data.filenames);
         string_array_destroy(&data.token_replacements);

--- a/vkrunner/CMakeLists.txt
+++ b/vkrunner/CMakeLists.txt
@@ -8,6 +8,7 @@ set(VKRUNNER_PUBLIC_HEADERS
         vr-format.h
         vr-inspect.h
         vr-result.h
+        vr-script.h
         vr-source.h
         vkrunner.h
         )

--- a/vkrunner/CMakeLists.txt
+++ b/vkrunner/CMakeLists.txt
@@ -4,6 +4,7 @@ include_directories(${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR})
 
 set(VKRUNNER_PUBLIC_HEADERS
         vr-callback.h
+        vr-config.h
         vr-executor.h
         vr-format.h
         vr-inspect.h
@@ -21,7 +22,8 @@ set(VKRUNNER_SOURCE_FILES
         vr-box.h
         vr-buffer.c
         vr-buffer.h
-        vr-config.h
+        vr-config.c
+        vr-config-private.h
         vr-context.c
         vr-context.h
         vr-enum-table.h

--- a/vkrunner/CMakeLists.txt
+++ b/vkrunner/CMakeLists.txt
@@ -43,7 +43,7 @@ set(VKRUNNER_SOURCE_FILES
         vr-pipeline-key.h
         vr-result.c
         vr-script.c
-        vr-script.h
+        vr-script-private.h
         vr-shader-stage.h
         vr-source-private.h
         vr-source.c

--- a/vkrunner/CMakeLists.txt
+++ b/vkrunner/CMakeLists.txt
@@ -9,6 +9,7 @@ set(VKRUNNER_PUBLIC_HEADERS
         vr-inspect.h
         vr-result.h
         vr-script.h
+        vr-shader-stage.h
         vr-source.h
         vkrunner.h
         )
@@ -45,7 +46,6 @@ set(VKRUNNER_SOURCE_FILES
         vr-result.c
         vr-script.c
         vr-script-private.h
-        vr-shader-stage.h
         vr-source-private.h
         vr-source.c
         vr-stream.c

--- a/vkrunner/vkrunner.h
+++ b/vkrunner/vkrunner.h
@@ -27,6 +27,7 @@
 #define VKRUNNER_H
 
 #include <vkrunner/vr-callback.h>
+#include <vkrunner/vr-config.h>
 #include <vkrunner/vr-script.h>
 #include <vkrunner/vr-executor.h>
 #include <vkrunner/vr-format.h>

--- a/vkrunner/vr-config-private.h
+++ b/vkrunner/vr-config-private.h
@@ -1,5 +1,7 @@
 /*
- * Copyright © 2011, 2016, 2018 Intel Corporation
+ * vkrunner
+ *
+ * Copyright (C) 2018 Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -21,60 +23,22 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef VR_VBO_H
-#define VR_VBO_H
+#ifndef VR_CONFIG_PRIVATE_H
+#define VR_CONFIG_PRIVATE_H
 
-#include <stdlib.h>
 #include <stdbool.h>
+#include "vr-config.h"
+#include "vr-callback.h"
+#include "vr-strtof.h"
 
-#include "vr-list.h"
-#include "vr-format.h"
-#include "vr-config-private.h"
+struct vr_config {
+        bool show_disassembly;
 
-struct vr_vbo_attrib {
-        struct vr_list link;
+        vr_callback_error error_cb;
+        vr_callback_inspect inspect_cb;
+        void *user_data;
 
-        const struct vr_format *format;
-
-        /**
-         * Vertex location
-         */
-        unsigned location;
-
-        /**
-         * Byte offset into the vertex data of this attribute.
-         */
-        size_t offset;
+        struct vr_strtof_data strtof_data;
 };
 
-struct vr_vbo {
-        /**
-         * Description of each attribute.
-         */
-        struct vr_list attribs;
-
-        /**
-         * Raw data buffer containing parsed numbers.
-         */
-        uint8_t *raw_data;
-
-        /**
-         * Number of bytes in each row of raw_data.
-         */
-        size_t stride;
-
-        /**
-         * Number of rows in raw_data.
-         */
-        size_t num_rows;
-};
-
-struct vr_vbo *
-vr_vbo_parse(const struct vr_config *config,
-             const char *text,
-             size_t text_length);
-
-void
-vr_vbo_free(struct vr_vbo *vbo);
-
-#endif /* VR_VBO_H */
+#endif /* VR_CONFIG_PRIVATE_H */

--- a/vkrunner/vr-config.c
+++ b/vkrunner/vr-config.c
@@ -1,5 +1,7 @@
 /*
- * Copyright © 2011, 2016, 2018 Intel Corporation
+ * vkrunner
+ *
+ * Copyright (C) 2018 Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -21,60 +23,50 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef VR_VBO_H
-#define VR_VBO_H
-
-#include <stdlib.h>
-#include <stdbool.h>
-
-#include "vr-list.h"
-#include "vr-format.h"
+#include "config.h"
 #include "vr-config-private.h"
+#include "vr-util.h"
 
-struct vr_vbo_attrib {
-        struct vr_list link;
+struct vr_config *
+vr_config_new(void)
+{
+        struct vr_config *config = vr_calloc(sizeof(struct vr_config));
+        vr_strtof_init(&config->strtof_data);
+        return config;
+}
 
-        const struct vr_format *format;
-
-        /**
-         * Vertex location
-         */
-        unsigned location;
-
-        /**
-         * Byte offset into the vertex data of this attribute.
-         */
-        size_t offset;
-};
-
-struct vr_vbo {
-        /**
-         * Description of each attribute.
-         */
-        struct vr_list attribs;
-
-        /**
-         * Raw data buffer containing parsed numbers.
-         */
-        uint8_t *raw_data;
-
-        /**
-         * Number of bytes in each row of raw_data.
-         */
-        size_t stride;
-
-        /**
-         * Number of rows in raw_data.
-         */
-        size_t num_rows;
-};
-
-struct vr_vbo *
-vr_vbo_parse(const struct vr_config *config,
-             const char *text,
-             size_t text_length);
 
 void
-vr_vbo_free(struct vr_vbo *vbo);
+vr_config_free(struct vr_config *config)
+{
+        vr_strtof_destroy(&config->strtof_data);
+        vr_free(config);
+}
 
-#endif /* VR_VBO_H */
+void
+vr_config_set_show_disassembly(struct vr_config *config,
+                               bool show_disassembly)
+{
+        config->show_disassembly = show_disassembly;
+}
+
+void
+vr_config_set_user_data(struct vr_config *config,
+                        void *user_data)
+{
+        config->user_data = user_data;
+}
+
+void
+vr_config_set_error_cb(struct vr_config *config,
+                       vr_callback_error error_cb)
+{
+        config->error_cb = error_cb;
+}
+
+void
+vr_config_set_inspect_cb(struct vr_config *config,
+                         vr_callback_inspect inspect_cb)
+{
+        config->inspect_cb = inspect_cb;
+}

--- a/vkrunner/vr-config.h
+++ b/vkrunner/vr-config.h
@@ -27,18 +27,51 @@
 #define VR_CONFIG_H
 
 #include <stdbool.h>
-#include "vr-result.h"
-#include "vr-callback.h"
-#include "vr-strtof.h"
+#include <vkrunner/vr-callback.h>
 
-struct vr_config {
-        bool show_disassembly;
+#ifdef  __cplusplus
+extern "C" {
+#endif
 
-        vr_callback_error error_cb;
-        vr_callback_inspect inspect_cb;
-        void *user_data;
+struct vr_config;
 
-        struct vr_strtof_data strtof_data;
-};
+/* Create a new vr_config object */
+struct vr_config *
+vr_config_new(void);
 
+/* Free a vr_config object */
+void
+vr_config_free(struct vr_config *config);
+
+void
+vr_config_set_show_disassembly(struct vr_config *config,
+                               bool show_disassembly);
+
+/* Sets a pointer to be passed back to the caller in all of the
+ * callback fuctions below.
+ */
+void
+vr_config_set_user_data(struct vr_config *config,
+                        void *user_data);
+
+/* Sets a callback that will be invoked whenever a test error is
+ * invoked such as a compilation error or a probed value was
+ * incorrect.
+ */
+void
+vr_config_set_error_cb(struct vr_config *config,
+                       vr_callback_error error_cb);
+
+/* Sets a callback to invoke after the commands in the test section
+ * have run. It is not invoked if the test fails before the test
+ * section is reached. The application can use the inspect struct to
+ * query the buffers used by the test.
+ */
+void
+vr_config_set_inspect_cb(struct vr_config *config,
+                         vr_callback_inspect inspect_cb);
+
+#ifdef  __cplusplus
+}
+#endif
 #endif /* VR_CONFIG_H */

--- a/vkrunner/vr-error-message.c
+++ b/vkrunner/vr-error-message.c
@@ -29,7 +29,7 @@
 #include <stdarg.h>
 
 #include "vr-error-message.h"
-#include "vr-config.h"
+#include "vr-config-private.h"
 #include "vr-buffer.h"
 
 void

--- a/vkrunner/vr-executor.c
+++ b/vkrunner/vr-executor.c
@@ -213,19 +213,11 @@ vr_executor_set_inspect_cb(struct vr_executor *executor,
 }
 
 enum vr_result
-vr_executor_execute(struct vr_executor *executor,
-                    const struct vr_source *source)
+vr_executor_execute_script(struct vr_executor *executor,
+                           const struct vr_script *script)
 {
         enum vr_result res = VR_RESULT_PASS;
-        struct vr_script *script = NULL;
         struct vr_pipeline *pipeline = NULL;
-
-        script = vr_script_load(&executor->config, source);
-
-        if (script == NULL) {
-                res = VR_RESULT_FAIL;
-                goto out;
-        }
 
         /* Recreate the context if the required features or extensions
          * have changed */
@@ -300,9 +292,28 @@ vr_executor_execute(struct vr_executor *executor,
 out:
         if (pipeline)
                 vr_pipeline_free(pipeline);
+
+        return res;
+}
+
+enum vr_result
+vr_executor_execute(struct vr_executor *executor,
+                    const struct vr_source *source)
+{
+        enum vr_result res = VR_RESULT_PASS;
+        struct vr_script *script = NULL;
+        script = vr_script_load(&executor->config, source);
+
+        if (script == NULL) {
+                res = VR_RESULT_FAIL;
+                goto out;
+        }
+
+        res = vr_executor_execute_script(executor, script);
+
+out:
         if (script)
                 vr_script_free(script);
-
         return res;
 }
 

--- a/vkrunner/vr-executor.c
+++ b/vkrunner/vr-executor.c
@@ -34,7 +34,7 @@
 
 #include "vr-vk.h"
 #include "vr-window.h"
-#include "vr-script.h"
+#include "vr-script-private.h"
 #include "vr-pipeline.h"
 #include "vr-test.h"
 #include "vr-config.h"

--- a/vkrunner/vr-executor.c
+++ b/vkrunner/vr-executor.c
@@ -37,7 +37,7 @@
 #include "vr-script-private.h"
 #include "vr-pipeline.h"
 #include "vr-test.h"
-#include "vr-config.h"
+#include "vr-config-private.h"
 #include "vr-error-message.h"
 #include "vr-source-private.h"
 

--- a/vkrunner/vr-executor.h
+++ b/vkrunner/vr-executor.h
@@ -43,7 +43,7 @@ extern "C" {
 #endif
 
 struct vr_executor *
-vr_executor_new(void);
+vr_executor_new(struct vr_config *config);
 
 /* Sets an externally created device to use for the execution. Note
  * that it is the callers responsibility to ensure that the device has
@@ -69,34 +69,6 @@ vr_executor_set_device(struct vr_executor *executor,
                        int queue_family,
                        /* VkDevice */
                        void *device);
-
-void
-vr_executor_set_show_disassembly(struct vr_executor *executor,
-                                 bool show_disassembly);
-
-/* Sets a pointer to be passed back to the caller in all of the
- * callback fuctions below.
- */
-void
-vr_executor_set_user_data(struct vr_executor *executor,
-                          void *user_data);
-
-/* Sets a callback that will be invoked whenever a test error is
- * invoked such as a compilation error or a probed value was
- * incorrect.
- */
-void
-vr_executor_set_error_cb(struct vr_executor *executor,
-                         vr_callback_error error_cb);
-
-/* Sets a callback to invoke after the commands in the test section
- * have run. It is not invoked if the test fails before the test
- * section is reached. The application can use the inspect struct to
- * query the buffers used by the test.
- */
-void
-vr_executor_set_inspect_cb(struct vr_executor *executor,
-                           vr_callback_inspect inspect_cb);
 
 enum vr_result
 vr_executor_execute(struct vr_executor *executor,

--- a/vkrunner/vr-executor.h
+++ b/vkrunner/vr-executor.h
@@ -102,6 +102,10 @@ enum vr_result
 vr_executor_execute(struct vr_executor *executor,
                     const struct vr_source *source);
 
+enum vr_result
+vr_executor_execute_script(struct vr_executor *executor,
+                           const struct vr_script *script);
+
 void
 vr_executor_free(struct vr_executor *executor);
 

--- a/vkrunner/vr-executor.h
+++ b/vkrunner/vr-executor.h
@@ -30,6 +30,7 @@
 #include <vkrunner/vr-result.h>
 #include <vkrunner/vr-source.h>
 #include <vkrunner/vr-callback.h>
+#include <vkrunner/vr-script.h>
 
 struct vr_executor;
 

--- a/vkrunner/vr-pipeline.c
+++ b/vkrunner/vr-pipeline.c
@@ -28,7 +28,7 @@
 #include "vr-pipeline.h"
 #include "vr-subprocess.h"
 #include "vr-util.h"
-#include "vr-script.h"
+#include "vr-script-private.h"
 #include "vr-error-message.h"
 #include "vr-buffer.h"
 #include "vr-temp-file.h"

--- a/vkrunner/vr-pipeline.h
+++ b/vkrunner/vr-pipeline.h
@@ -26,7 +26,7 @@
 #ifndef VR_PIPELINE_H
 #define VR_PIPELINE_H
 
-#include "vr-script.h"
+#include "vr-script-private.h"
 #include "vr-window.h"
 #include "vr-config.h"
 #include "vr-pipeline-key.h"

--- a/vkrunner/vr-script-private.h
+++ b/vkrunner/vr-script-private.h
@@ -23,9 +23,10 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef VR_SCRIPT_H
-#define VR_SCRIPT_H
+#ifndef VR_SCRIPT_PRIVATE_H
+#define VR_SCRIPT_PRIVATE_H
 
+#include "vr-script-private.h"
 #include "vr-list.h"
 #include "vr-vk.h"
 #include "vr-vbo.h"
@@ -163,4 +164,4 @@ vr_script_load(const struct vr_config *config,
 void
 vr_script_free(struct vr_script *script);
 
-#endif /* VR_SCRIPT_H */
+#endif /* VR_SCRIPT_PRIVATE_H */

--- a/vkrunner/vr-script-private.h
+++ b/vkrunner/vr-script-private.h
@@ -151,8 +151,4 @@ struct vr_script {
         size_t n_buffers;
 };
 
-struct vr_script *
-vr_script_load(const struct vr_config *config,
-               const struct vr_source *source);
-
 #endif /* VR_SCRIPT_PRIVATE_H */

--- a/vkrunner/vr-script-private.h
+++ b/vkrunner/vr-script-private.h
@@ -155,7 +155,4 @@ struct vr_script *
 vr_script_load(const struct vr_config *config,
                const struct vr_source *source);
 
-void
-vr_script_free(struct vr_script *script);
-
 #endif /* VR_SCRIPT_PRIVATE_H */

--- a/vkrunner/vr-script-private.h
+++ b/vkrunner/vr-script-private.h
@@ -26,7 +26,7 @@
 #ifndef VR_SCRIPT_PRIVATE_H
 #define VR_SCRIPT_PRIVATE_H
 
-#include "vr-script-private.h"
+#include "vr-script.h"
 #include "vr-list.h"
 #include "vr-vk.h"
 #include "vr-vbo.h"
@@ -48,12 +48,6 @@ enum vr_script_op {
         VR_SCRIPT_OP_SET_PUSH_CONSTANT,
         VR_SCRIPT_OP_SET_BUFFER_SUBDATA,
         VR_SCRIPT_OP_CLEAR
-};
-
-enum vr_script_source_type {
-        VR_SCRIPT_SOURCE_TYPE_GLSL,
-        VR_SCRIPT_SOURCE_TYPE_SPIRV,
-        VR_SCRIPT_SOURCE_TYPE_BINARY
 };
 
 struct vr_script_shader {

--- a/vkrunner/vr-script-private.h
+++ b/vkrunner/vr-script-private.h
@@ -32,7 +32,7 @@
 #include "vr-vbo.h"
 #include "vr-format.h"
 #include "vr-pipeline-key.h"
-#include "vr-config.h"
+#include "vr-config-private.h"
 #include "vr-box.h"
 #include "vr-source.h"
 #include "vr-shader-stage.h"

--- a/vkrunner/vr-script.c
+++ b/vkrunner/vr-script.c
@@ -115,7 +115,7 @@ vertex_shader_passthrough[] = {
 };
 
 static void
-add_shader(struct load_state *data,
+add_shader(struct vr_script *script,
            enum vr_shader_stage stage,
            enum vr_script_source_type source_type,
            size_t length,
@@ -128,13 +128,13 @@ add_shader(struct load_state *data,
         shader->source_type = source_type;
         memcpy(shader->source, source, length);
 
-        vr_list_insert(data->script->stages[stage].prev, &shader->link);
+        vr_list_insert(script->stages[stage].prev, &shader->link);
 }
 
 static bool
 end_shader(struct load_state *data)
 {
-        add_shader(data,
+        add_shader(data->script,
                    data->current_stage,
                    data->current_source_type,
                    data->buffer.length,
@@ -1967,7 +1967,7 @@ process_section_header(struct load_state *data)
                 if (!start_spirv_shader(data, VR_SHADER_STAGE_VERTEX))
                         return false;
                 set_current_section(data, SECTION_NONE);
-                add_shader(data,
+                add_shader(data->script,
                            VR_SHADER_STAGE_VERTEX,
                            VR_SCRIPT_SOURCE_TYPE_BINARY,
                            sizeof vertex_shader_passthrough,

--- a/vkrunner/vr-script.c
+++ b/vkrunner/vr-script.c
@@ -34,7 +34,7 @@
 #include <assert.h>
 #include <stdlib.h>
 
-#include "vr-script.h"
+#include "vr-script-private.h"
 #include "vr-list.h"
 #include "vr-util.h"
 #include "vr-buffer.h"

--- a/vkrunner/vr-script.c
+++ b/vkrunner/vr-script.c
@@ -2413,3 +2413,30 @@ vr_script_free(struct vr_script *script)
 
         vr_free(script);
 }
+
+int
+vr_script_get_shaders(const struct vr_script *script,
+                      const struct vr_source *source,
+                      struct vr_script_shader_code *shaders)
+{
+        int shaders_number = 0;
+        int stage;
+        struct vr_script_shader *shader, *tmp;
+
+        for (stage = 0; stage < VR_SHADER_STAGE_N_STAGES; stage++) {
+                vr_list_for_each_safe(shader,
+                                      tmp,
+                                      &script->stages[stage],
+                                      link) {
+                        shaders[shaders_number].source_type = shader->source_type;
+                        shaders[shaders_number].source_length = shader->length;
+                        shaders[shaders_number].stage = stage;
+                        shaders[shaders_number].source = (char*) malloc(shader->length + 1);
+                        memcpy(shaders[shaders_number].source, shader->source, shader->length);
+                        shaders[shaders_number].source[shader->length] = '\0';
+                        shaders_number++;
+                }
+        }
+
+        return shaders_number;
+}

--- a/vkrunner/vr-script.c
+++ b/vkrunner/vr-script.c
@@ -2451,3 +2451,27 @@ vr_script_get_num_shaders(const struct vr_script* script)
         }
         return num_shaders;
 }
+
+void
+vr_script_replace_shaders_stage_binary(struct vr_script *script,
+                                       enum vr_shader_stage stage,
+                                       size_t source_length,
+                                       const uint32_t *source)
+{
+        struct vr_script_shader *shader, *tmp;
+
+        /* Remove all the shaders of the stage */
+        vr_list_for_each_safe(shader,
+                              tmp,
+                              &script->stages[stage],
+                              link) {
+                vr_list_remove(&shader->link);
+                vr_free(shader);
+        }
+        /* Add the new shader for the stage */
+        add_shader(script,
+                   stage,
+                   VR_SCRIPT_SOURCE_TYPE_BINARY,
+                   source_length,
+                   (const char *) source);
+}

--- a/vkrunner/vr-script.c
+++ b/vkrunner/vr-script.c
@@ -2440,3 +2440,14 @@ vr_script_get_shaders(const struct vr_script *script,
 
         return shaders_number;
 }
+
+int
+vr_script_get_num_shaders(const struct vr_script* script)
+{
+        int stage, num_shaders = 0;
+
+        for (stage = 0; stage < VR_SHADER_STAGE_N_STAGES; stage++) {
+                num_shaders += vr_list_length(&script->stages[stage]);
+        }
+        return num_shaders;
+}

--- a/vkrunner/vr-script.h
+++ b/vkrunner/vr-script.h
@@ -59,6 +59,10 @@ vr_script_get_shaders(const struct vr_script *script,
                       const struct vr_source *source,
                       struct vr_script_shader_code *shaders);
 
+/* Returns the total number of shaders present in the provided shader_test */
+int
+vr_script_get_num_shaders(const struct vr_script *script);
+
 void
 vr_script_free(struct vr_script *script);
 

--- a/vkrunner/vr-script.h
+++ b/vkrunner/vr-script.h
@@ -26,6 +26,8 @@
 #ifndef VR_SCRIPT_H
 #define VR_SCRIPT_H
 
+#include <stddef.h>
+#include <vkrunner/vr-shader-stage.h>
 #include <vkrunner/vr-source.h>
 
 #ifdef  __cplusplus
@@ -37,6 +39,25 @@ enum vr_script_source_type {
         VR_SCRIPT_SOURCE_TYPE_SPIRV,
         VR_SCRIPT_SOURCE_TYPE_BINARY
 };
+
+struct vr_script;
+
+struct vr_script_shader_code {
+	enum vr_script_source_type source_type;
+	enum vr_shader_stage stage;
+	size_t source_length;
+	char *source;
+};
+
+/* Writes the source code of the GLSL shaders in shaders parameter.
+ * The returned integer value said how many of them there are.
+ *
+ * NOTE: Callers should free shaders[i].source memory manually.
+ */
+int
+vr_script_get_shaders(const struct vr_script *script,
+                      const struct vr_source *source,
+                      struct vr_script_shader_code *shaders);
 
 #ifdef  __cplusplus
 }

--- a/vkrunner/vr-script.h
+++ b/vkrunner/vr-script.h
@@ -27,6 +27,7 @@
 #define VR_SCRIPT_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include <vkrunner/vr-shader-stage.h>
 #include <vkrunner/vr-source.h>
 
@@ -62,6 +63,13 @@ vr_script_get_shaders(const struct vr_script *script,
 /* Returns the total number of shaders present in the provided shader_test */
 int
 vr_script_get_num_shaders(const struct vr_script *script);
+
+/* Replaces the non-binary shaders by the binary version compiled by the caller */
+void
+vr_script_replace_shaders_stage_binary(struct vr_script *script,
+                                       enum vr_shader_stage stage,
+                                       size_t source_length,
+                                       const uint32_t *source);
 
 void
 vr_script_free(struct vr_script *script);

--- a/vkrunner/vr-script.h
+++ b/vkrunner/vr-script.h
@@ -23,15 +23,22 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef VKRUNNER_H
-#define VKRUNNER_H
+#ifndef VR_SCRIPT_H
+#define VR_SCRIPT_H
 
-#include <vkrunner/vr-callback.h>
-#include <vkrunner/vr-script.h>
-#include <vkrunner/vr-executor.h>
-#include <vkrunner/vr-format.h>
-#include <vkrunner/vr-inspect.h>
-#include <vkrunner/vr-result.h>
 #include <vkrunner/vr-source.h>
 
-#endif /* VKRUNNER_H */
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+enum vr_script_source_type {
+        VR_SCRIPT_SOURCE_TYPE_GLSL,
+        VR_SCRIPT_SOURCE_TYPE_SPIRV,
+        VR_SCRIPT_SOURCE_TYPE_BINARY
+};
+
+#ifdef  __cplusplus
+}
+#endif
+#endif /* VR_SCRIPT_H */

--- a/vkrunner/vr-script.h
+++ b/vkrunner/vr-script.h
@@ -29,6 +29,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <vkrunner/vr-shader-stage.h>
+#include <vkrunner/vr-config.h>
 #include <vkrunner/vr-source.h>
 
 #ifdef  __cplusplus
@@ -73,6 +74,10 @@ vr_script_replace_shaders_stage_binary(struct vr_script *script,
 
 void
 vr_script_free(struct vr_script *script);
+
+struct vr_script *
+vr_script_load(const struct vr_config *config,
+               const struct vr_source *source);
 
 #ifdef  __cplusplus
 }

--- a/vkrunner/vr-script.h
+++ b/vkrunner/vr-script.h
@@ -59,6 +59,9 @@ vr_script_get_shaders(const struct vr_script *script,
                       const struct vr_source *source,
                       struct vr_script_shader_code *shaders);
 
+void
+vr_script_free(struct vr_script *script);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/vkrunner/vr-test.h
+++ b/vkrunner/vr-test.h
@@ -29,7 +29,7 @@
 #include <stdbool.h>
 
 #include "vr-pipeline.h"
-#include "vr-script.h"
+#include "vr-script-private.h"
 #include "vr-window.h"
 
 bool


### PR DESCRIPTION
This is a RFC to gather feedback about CTS integration without requiring glslangValidator binary for precompiling the shaders.

This branch sets up the required bits that allow CTS to get the number of GLSL-written stages present in a given shader_test, get their GLSL code, replace them with a SPIR-V binary form and execute them. CTS will compile GLSL shaders using glslang library on run time, or using a prebuilt version of them if glslang is not present.

Right now, text-format SPIR-V shaders are not supported. I will work on that later.