### PR TITLE
Add a command to set the framebuffer size

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -51,7 +51,8 @@ VKRUNNER_SRC_FILES := vkrunner/vr-allocate-store.c \
 	vkrunner/vr-util.c \
 	vkrunner/vr-vbo.c \
 	vkrunner/vr-vk.c \
-	vkrunner/vr-window.c
+	vkrunner/vr-window.c \
+	vkrunner/vr-window-format.c
 
 define gen_config_h
 $(call generate-file-dir,$(LOCAL_PATH)/config.h)

--- a/README.md
+++ b/README.md
@@ -229,6 +229,11 @@ If this is specified VkRunner will try to add a depth-stencil
 attachment to the framebuffer with the given format. Without it no
 depth-stencil buffer will be created.
 
+> fbsize _width_ _height_
+
+Specify the size of the framebuffer. If not specified it defaults to
+250x250.
+
 ## Shader sections
 
 Shaders can be stored in sections like `[vertex shader]` just like in

--- a/vkrunner/CMakeLists.txt
+++ b/vkrunner/CMakeLists.txt
@@ -72,6 +72,8 @@ set(VKRUNNER_SOURCE_FILES
         vr-vbo.h
         vr-window.c
         vr-window.h
+        vr-window-format.c
+        vr-window-format.h
         ${VKRUNNER_PUBLIC_HEADERS}
         )
 

--- a/vkrunner/vr-executor.c
+++ b/vkrunner/vr-executor.c
@@ -121,16 +121,6 @@ context_is_compatible(struct vr_executor *executor,
         return true;
 }
 
-static bool
-window_is_compatible(struct vr_executor *executor,
-                     const struct vr_script *script)
-{
-        struct vr_window *window = executor->window;
-
-        return (script->framebuffer_format == window->framebuffer_format &&
-                script->depth_stencil_format == window->depth_stencil_format);
-}
-
 static void
 copy_extensions(struct vr_executor *executor,
                 const char * const *extensions)
@@ -243,7 +233,9 @@ vr_executor_execute(struct vr_executor *executor,
                 free_context(executor);
 
         /* Recreate the window if the framebuffer format is different */
-        if (executor->window && !window_is_compatible(executor, script))
+        if (executor->window &&
+            !vr_window_format_equal(&executor->window->format,
+                                    &script->window_format))
                 free_window(executor);
 
         if (executor->context == NULL) {
@@ -287,8 +279,7 @@ vr_executor_execute(struct vr_executor *executor,
 
         if (executor->window == NULL) {
                 res = vr_window_new(executor->context,
-                                    script->framebuffer_format,
-                                    script->depth_stencil_format,
+                                    &script->window_format,
                                     &executor->window);
                 if (res != VR_RESULT_PASS)
                         goto out;

--- a/vkrunner/vr-pipeline.c
+++ b/vkrunner/vr-pipeline.c
@@ -59,32 +59,6 @@ stage_names[VR_SHADER_STAGE_N_STAGES] = {
         [VR_SHADER_STAGE_COMPUTE] = "comp",
 };
 
-static const VkViewport
-base_viewports[] = {
-        {
-                .width = VR_WINDOW_WIDTH,
-                .height = VR_WINDOW_HEIGHT,
-                .minDepth = 0.0f,
-                .maxDepth = 1.0f
-        }
-};
-
-static const VkRect2D
-base_scissors[] = {
-        {
-                .extent = { VR_WINDOW_WIDTH, VR_WINDOW_HEIGHT }
-        }
-};
-
-static const VkPipelineViewportStateCreateInfo
-base_viewport_state = {
-        .sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
-        .viewportCount = VR_N_ELEMENTS(base_viewports),
-        .pViewports = base_viewports,
-        .scissorCount = VR_N_ELEMENTS(base_scissors),
-        .pScissors = base_scissors
-};
-
 static const VkPipelineMultisampleStateCreateInfo
 base_multisample_state = {
         .sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
@@ -497,6 +471,28 @@ create_vk_pipeline(struct vr_pipeline *pipeline,
                 VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO
         };
 
+        VkViewport viewports[] = {
+                {
+                        .width = window->format.width,
+                        .height = window->format.height,
+                        .minDepth = 0.0f,
+                        .maxDepth = 1.0f
+                }
+        };
+        VkRect2D scissors[] = {
+                {
+                        .extent = { window->format.width,
+                                    window->format.height }
+                }
+        };
+        VkPipelineViewportStateCreateInfo viewport_state = {
+                .sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
+                .viewportCount = VR_N_ELEMENTS(viewports),
+                .pViewports = viewports,
+                .scissorCount = VR_N_ELEMENTS(scissors),
+                .pScissors = scissors
+        };
+
         VkPipelineRasterizationStateCreateInfo rasterization_state = {
                 .sType =
                 VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO
@@ -530,7 +526,7 @@ create_vk_pipeline(struct vr_pipeline *pipeline,
 
         VkGraphicsPipelineCreateInfo info = {
                 .sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
-                .pViewportState = &base_viewport_state,
+                .pViewportState = &viewport_state,
                 .pRasterizationState = &rasterization_state,
                 .pMultisampleState = &base_multisample_state,
                 .pDepthStencilState = &depth_stencil_state,

--- a/vkrunner/vr-script.c
+++ b/vkrunner/vr-script.c
@@ -1015,12 +1015,14 @@ process_draw_rect_command(struct load_state *data,
         command->op = VR_SCRIPT_OP_DRAW_RECT;
 
         if (ortho) {
+                float width = data->script->window_format.width;
+                float height = data->script->window_format.height;
                 command->draw_rect.x = (command->draw_rect.x * 2.0f /
-                                        VR_WINDOW_WIDTH) - 1.0f;
+                                        width) - 1.0f;
                 command->draw_rect.y = (command->draw_rect.y * 2.0f /
-                                        VR_WINDOW_HEIGHT) - 1.0f;
-                command->draw_rect.w *= 2.0f / VR_WINDOW_WIDTH;
-                command->draw_rect.h *= 2.0f / VR_WINDOW_HEIGHT;
+                                        height) - 1.0f;
+                command->draw_rect.w *= 2.0f / width;
+                command->draw_rect.h *= 2.0f / height;
         }
 
         return true;
@@ -1058,6 +1060,9 @@ process_probe_command(struct load_state *data,
         command->op = VR_SCRIPT_OP_PROBE_RECT;
         command->probe_rect.n_components = n_components;
 
+        size_t window_width = data->script->window_format.width;
+        size_t window_height = data->script->window_format.height;
+
         if (region_type == ALL) {
                 if (relative)
                         return false;
@@ -1071,8 +1076,8 @@ process_probe_command(struct load_state *data,
                         return false;
                 command->probe_rect.x = 0;
                 command->probe_rect.y = 0;
-                command->probe_rect.w = VR_WINDOW_WIDTH;
-                command->probe_rect.h = VR_WINDOW_HEIGHT;
+                command->probe_rect.w = window_width;
+                command->probe_rect.h = window_height;
                 return true;
         }
 
@@ -1087,8 +1092,8 @@ process_probe_command(struct load_state *data,
                         float rel_pos[2];
                         if (!parse_floats(data, &p, rel_pos, 2, ","))
                                 return false;
-                        command->probe_rect.x = rel_pos[0] * VR_WINDOW_WIDTH;
-                        command->probe_rect.y = rel_pos[1] * VR_WINDOW_HEIGHT;
+                        command->probe_rect.x = rel_pos[0] * window_width;
+                        command->probe_rect.y = rel_pos[1] * window_height;
                 } else if (!parse_ints(&p, &command->probe_rect.x, 2, ",")) {
                         return false;
                 }
@@ -1101,10 +1106,10 @@ process_probe_command(struct load_state *data,
                         float rel_pos[4];
                         if (!parse_floats(data, &p, rel_pos, 4, ","))
                                 return false;
-                        command->probe_rect.x = rel_pos[0] * VR_WINDOW_WIDTH;
-                        command->probe_rect.y = rel_pos[1] * VR_WINDOW_HEIGHT;
-                        command->probe_rect.w = rel_pos[2] * VR_WINDOW_WIDTH;
-                        command->probe_rect.h = rel_pos[3] * VR_WINDOW_HEIGHT;
+                        command->probe_rect.x = rel_pos[0] * window_width;
+                        command->probe_rect.y = rel_pos[1] * window_height;
+                        command->probe_rect.w = rel_pos[2] * window_width;
+                        command->probe_rect.h = rel_pos[3] * window_height;
                 } else if (!parse_ints(&p, &command->probe_rect.x, 4, ",")) {
                         return false;
                 }
@@ -2251,6 +2256,8 @@ vr_script_load(const struct vr_config *config,
 
         vr_pipeline_key_init(&data.current_key);
 
+        script->window_format.width = 250;
+        script->window_format.height = 250;
         script->window_format.color_format =
                 vr_format_lookup_by_vk_format(VK_FORMAT_B8G8R8A8_UNORM);
         assert(script->window_format.color_format != NULL);

--- a/vkrunner/vr-script.c
+++ b/vkrunner/vr-script.c
@@ -822,6 +822,29 @@ parse_format(struct load_state *data,
 }
 
 static bool
+parse_fbsize(struct load_state *data,
+             const char *p,
+             struct vr_window_format *format)
+{
+        unsigned parts[2];
+
+        if (!parse_uints(&p, parts, 2, NULL) ||
+            parts[0] == 0 || parts[1] == 0 ||
+            !is_end(p)) {
+                vr_error_message(data->config,
+                                 "%s:%i: Invalid fbsize",
+                                 data->filename,
+                                 data->line_num);
+                return false;
+        }
+
+        format->width = parts[0];
+        format->height = parts[1];
+
+        return true;
+}
+
+static bool
 parse_tolerance(struct load_state *data,
                 const char *p,
                 int n_tolerance,
@@ -923,6 +946,9 @@ process_require_line(struct load_state *data)
                         &data->script->window_format;
                 return parse_format(data, p, &format->depth_stencil_format);
         }
+
+        if (looking_at(&p, "fbsize "))
+                return parse_fbsize(data, p, &data->script->window_format);
 
         int extension_len = 0;
 

--- a/vkrunner/vr-script.c
+++ b/vkrunner/vr-script.c
@@ -912,15 +912,15 @@ process_require_line(struct load_state *data)
         }
 
         if (looking_at(&p, "framebuffer ")) {
-                return parse_format(data,
-                                    p,
-                                    &data->script->framebuffer_format);
+                struct vr_window_format *format =
+                        &data->script->window_format;
+                return parse_format(data, p, &format->color_format);
         }
 
         if (looking_at(&p, "depthstencil ")) {
-                return parse_format(data,
-                                    p,
-                                    &data->script->depth_stencil_format);
+                struct vr_window_format *format =
+                        &data->script->window_format;
+                return parse_format(data, p, &format->depth_stencil_format);
         }
 
         int extension_len = 0;
@@ -2251,9 +2251,9 @@ vr_script_load(const struct vr_config *config,
 
         vr_pipeline_key_init(&data.current_key);
 
-        script->framebuffer_format =
+        script->window_format.color_format =
                 vr_format_lookup_by_vk_format(VK_FORMAT_B8G8R8A8_UNORM);
-        assert(script->framebuffer_format != NULL);
+        assert(script->window_format.color_format != NULL);
 
         vr_buffer_set_length(&data.extensions, sizeof (const char *));
         memset(data.extensions.data, 0, data.extensions.length);

--- a/vkrunner/vr-script.h
+++ b/vkrunner/vr-script.h
@@ -36,6 +36,7 @@
 #include "vr-source.h"
 #include "vr-shader-stage.h"
 #include "vr-tolerance.h"
+#include "vr-window-format.h"
 
 enum vr_script_op {
         VR_SCRIPT_OP_DRAW_RECT,
@@ -147,8 +148,7 @@ struct vr_script {
         struct vr_pipeline_key *pipeline_keys;
         VkPhysicalDeviceFeatures required_features;
         const char *const *extensions;
-        const struct vr_format *framebuffer_format;
-        const struct vr_format *depth_stencil_format;
+        struct vr_window_format window_format;
         struct vr_vbo *vertex_data;
         uint16_t *indices;
         size_t n_indices;

--- a/vkrunner/vr-test.c
+++ b/vkrunner/vr-test.c
@@ -712,7 +712,8 @@ probe_rect(struct test_data *data,
            const struct vr_script_command *command)
 {
         int n_components = command->probe_rect.n_components;
-        const struct vr_format *format = data->window->framebuffer_format;
+        const struct vr_format *format =
+                data->window->format.color_format;
         int format_size = vr_format_get_size(format);
 
         /* End the paint to copy the framebuffer into the linear buffer */
@@ -1052,9 +1053,9 @@ clear(struct test_data *data,
 
         VkImageAspectFlags depth_stencil_flags = 0;
         const struct vr_format *depth_stencil_format =
-                data->window->depth_stencil_format;
+                data->window->format.depth_stencil_format;
 
-        if (data->window->depth_stencil_format) {
+        if (depth_stencil_format) {
                 for (int i = 0; i < depth_stencil_format->n_parts; i++) {
                         switch (depth_stencil_format->parts[i].component) {
                         case VR_FORMAT_COMPONENT_D:
@@ -1186,7 +1187,7 @@ call_inspect(struct test_data *data)
         color_buffer->width = VR_WINDOW_WIDTH;
         color_buffer->height = VR_WINDOW_HEIGHT;
         color_buffer->stride = data->window->linear_memory_stride;
-        color_buffer->format = data->window->framebuffer_format;
+        color_buffer->format = data->window->format.color_format;
         color_buffer->data = data->window->linear_memory_map;
 
         data->window->config->inspect_cb(&inspect_data,

--- a/vkrunner/vr-test.c
+++ b/vkrunner/vr-test.c
@@ -291,7 +291,8 @@ begin_render_pass(struct test_data *data)
                 .renderArea = {
                         .offset = { 0, 0 },
                         .extent = {
-                                VR_WINDOW_WIDTH, VR_WINDOW_HEIGHT
+                                data->window->format.width,
+                                data->window->format.height
                         }
                 },
         };
@@ -316,8 +317,8 @@ end_render_pass(struct test_data *data)
 
         VkBufferImageCopy copy_region = {
                 .bufferOffset = 0,
-                .bufferRowLength = VR_WINDOW_WIDTH,
-                .bufferImageHeight = VR_WINDOW_HEIGHT,
+                .bufferRowLength = data->window->format.width,
+                .bufferImageHeight = data->window->format.height,
                 .imageSubresource = {
                         .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
                         .mipLevel = 0,
@@ -325,7 +326,10 @@ end_render_pass(struct test_data *data)
                         .layerCount = 1
                 },
                 .imageOffset = { 0, 0, 0 },
-                .imageExtent = { VR_WINDOW_WIDTH, VR_WINDOW_HEIGHT, 1 }
+                .imageExtent = {
+                        data->window->format.width,
+                        data->window->format.height
+                }
         };
         vkfn->vkCmdCopyImageToBuffer(window->context->command_buffer,
                                      window->color_image,
@@ -1087,7 +1091,10 @@ clear(struct test_data *data,
         VkClearRect clear_rect = {
                 .rect = {
                         .offset = { 0, 0 },
-                        .extent = { VR_WINDOW_WIDTH, VR_WINDOW_HEIGHT }
+                        .extent = {
+                                data->window->format.width,
+                                data->window->format.height
+                        }
                 },
                 .baseArrayLayer = 0,
                 .layerCount = 1
@@ -1184,8 +1191,8 @@ call_inspect(struct test_data *data)
 
         struct vr_inspect_image *color_buffer = &inspect_data.color_buffer;
 
-        color_buffer->width = VR_WINDOW_WIDTH;
-        color_buffer->height = VR_WINDOW_HEIGHT;
+        color_buffer->width = data->window->format.width;
+        color_buffer->height = data->window->format.height;
         color_buffer->stride = data->window->linear_memory_stride;
         color_buffer->format = data->window->format.color_format;
         color_buffer->data = data->window->linear_memory_map;

--- a/vkrunner/vr-window-format.c
+++ b/vkrunner/vr-window-format.c
@@ -1,0 +1,36 @@
+/*
+ * vkrunner
+ *
+ * Copyright (C) 2013, 2014, 2015, 2017 Neil Roberts
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "config.h"
+
+#include "vr-window-format.h"
+
+bool
+vr_window_format_equal(const struct vr_window_format *a,
+                       const struct vr_window_format *b)
+{
+        return (a->color_format == b->color_format &&
+                a->depth_stencil_format == b->depth_stencil_format);
+}

--- a/vkrunner/vr-window-format.c
+++ b/vkrunner/vr-window-format.c
@@ -32,5 +32,7 @@ vr_window_format_equal(const struct vr_window_format *a,
                        const struct vr_window_format *b)
 {
         return (a->color_format == b->color_format &&
-                a->depth_stencil_format == b->depth_stencil_format);
+                a->depth_stencil_format == b->depth_stencil_format &&
+                a->width == b->width &&
+                a->height == b->height);
 }

--- a/vkrunner/vr-window-format.h
+++ b/vkrunner/vr-window-format.h
@@ -28,10 +28,12 @@
 
 #include "vr-format.h"
 #include <stdbool.h>
+#include <stdlib.h>
 
 struct vr_window_format {
         const struct vr_format *color_format;
         const struct vr_format *depth_stencil_format;
+        size_t width, height;
 };
 
 bool

--- a/vkrunner/vr-window-format.h
+++ b/vkrunner/vr-window-format.h
@@ -1,0 +1,41 @@
+/*
+ * vkrunner
+ *
+ * Copyright (C) 2018 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef VR_WINDOW_FORMAT_H
+#define VR_WINDOW_FORMAT_H
+
+#include "vr-format.h"
+#include <stdbool.h>
+
+struct vr_window_format {
+        const struct vr_format *color_format;
+        const struct vr_format *depth_stencil_format;
+};
+
+bool
+vr_window_format_equal(const struct vr_window_format *a,
+                       const struct vr_window_format *b);
+
+#endif /* VR_WINDOW_FORMAT_H */

--- a/vkrunner/vr-window.c
+++ b/vkrunner/vr-window.c
@@ -121,8 +121,8 @@ init_depth_stencil_resources(struct vr_window *window)
                 .imageType = VK_IMAGE_TYPE_2D,
                 .format = window->format.depth_stencil_format->vk_format,
                 .extent = {
-                        .width = VR_WINDOW_WIDTH,
-                        .height = VR_WINDOW_HEIGHT,
+                        .width = window->format.width,
+                        .height = window->format.height,
                         .depth = 1
                 },
                 .mipLevels = 1,
@@ -323,8 +323,8 @@ init_framebuffer_resources(struct vr_window *window)
                 .imageType = VK_IMAGE_TYPE_2D,
                 .format = window->format.color_format->vk_format,
                 .extent = {
-                        .width = VR_WINDOW_WIDTH,
-                        .height = VR_WINDOW_HEIGHT,
+                        .width = window->format.width,
+                        .height = window->format.height,
                         .depth = 1
                 },
                 .mipLevels = 1,
@@ -353,11 +353,11 @@ init_framebuffer_resources(struct vr_window *window)
                                       NULL /* memory_type_index */);
 
         int format_size = vr_format_get_size(window->format.color_format);
-        window->linear_memory_stride = format_size * VR_WINDOW_WIDTH;
+        window->linear_memory_stride = format_size * window->format.width;
 
         struct VkBufferCreateInfo buffer_create_info = {
                 .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
-                .size = window->linear_memory_stride * VR_WINDOW_HEIGHT,
+                .size = window->linear_memory_stride * window->format.height,
                 .usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                 .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
         };
@@ -446,8 +446,8 @@ init_framebuffer_resources(struct vr_window *window)
                                     VR_N_ELEMENTS(attachments) :
                                     VR_N_ELEMENTS(attachments) - 1),
                 .pAttachments = attachments,
-                .width = VR_WINDOW_WIDTH,
-                .height = VR_WINDOW_HEIGHT,
+                .width = window->format.width,
+                .height = window->format.height,
                 .layers = 1
         };
         res = vkfn->vkCreateFramebuffer(window->device,

--- a/vkrunner/vr-window.h
+++ b/vkrunner/vr-window.h
@@ -34,9 +34,6 @@
 #include "vr-context.h"
 #include "vr-window-format.h"
 
-#define VR_WINDOW_WIDTH 250
-#define VR_WINDOW_HEIGHT 250
-
 struct vr_window {
         struct vr_context *context;
 

--- a/vkrunner/vr-window.h
+++ b/vkrunner/vr-window.h
@@ -32,6 +32,7 @@
 #include "vr-result.h"
 #include "vr-config.h"
 #include "vr-context.h"
+#include "vr-window-format.h"
 
 #define VR_WINDOW_WIDTH 250
 #define VR_WINDOW_HEIGHT 250
@@ -62,14 +63,12 @@ struct vr_window {
         VkDeviceMemory depth_image_memory;
         VkImageView depth_image_view;
         VkFramebuffer framebuffer;
-        const struct vr_format *framebuffer_format;
-        const struct vr_format *depth_stencil_format;
+        struct vr_window_format format;
 };
 
 enum vr_result
 vr_window_new(struct vr_context *context,
-              const struct vr_format *framebuffer_format,
-              const struct vr_format *depth_stencil_format,
+              const struct vr_window_format *format,
               struct vr_window **window_out);
 
 void


### PR DESCRIPTION
This adds a command to the `[require]` section to set the framebuffer size. Previously it was hard-coded to 250x250. The command looks like:

> [require]
> fbsize 800 600