### PR TITLE
Define VULKAN_HEADER variable to set where external vulkan headers are.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,18 +45,26 @@ if(HAVE_FFSL)
   add_definitions(-DHAVE_FFSL)
 endif()
 
-pkg_check_modules(VULKAN vulkan)
-if(NOT VULKAN_FOUND)
-  CHECK_INCLUDE_FILE(vulkan/vulkan.h HAVE_VULKAN_HEADER)
-  if(NOT HAVE_VULKAN_HEADER)
-    message(FATAL_ERROR
-      "No vulkan pkg-config package nor vulkan header was found")
+if (NOT VULKAN_HEADER)
+  pkg_check_modules(VULKAN vulkan)
+  if(NOT VULKAN_FOUND)
+    CHECK_INCLUDE_FILE(vulkan/vulkan.h HAVE_VULKAN_HEADER)
+    if(NOT HAVE_VULKAN_HEADER)
+      message(FATAL_ERROR
+	"No vulkan pkg-config package nor vulkan header was found")
+    endif()
   endif()
+  set(VULKAN_HEADER "<vulkan/vulkan.h>")
 endif()
 
 configure_file(
   "${PROJECT_SOURCE_DIR}/config.h.in"
   "${PROJECT_BINARY_DIR}/config.h"
+  )
+
+configure_file(
+  "${PROJECT_SOURCE_DIR}/vk-vulkan-header.h.in"
+  "${PROJECT_BINARY_DIR}/vk-vulkan-header.h"
   )
 
 add_subdirectory(vkrunner)

--- a/vk-vulkan-header.h.in
+++ b/vk-vulkan-header.h.in
@@ -1,0 +1,1 @@
+#include @VULKAN_HEADER@

--- a/vkrunner/vr-vk.h
+++ b/vkrunner/vr-vk.h
@@ -26,8 +26,8 @@
 #ifndef VR_VK_H
 #define VR_VK_H
 
-#include <vulkan/vulkan.h>
 #include <stdbool.h>
+#include "vk-vulkan-header.h"
 #include "vr-config.h"
 
 struct vr_vk {


### PR DESCRIPTION
This way, we don't need to depend on vulkan or vulkan-headers packages. This is specially interesting for integrating VkRunner into CTS, where it generates its own headers.