### PR TITLE
Fix non-sequential descripter set IDs

### DIFF
--- a/vkrunner/vr-pipeline.h
+++ b/vkrunner/vr-pipeline.h
@@ -36,7 +36,6 @@ struct vr_pipeline {
         VkPipelineLayout layout;
         VkDescriptorPool descriptor_pool;
         VkDescriptorSetLayout *descriptor_set_layout;
-        unsigned *desc_sets;
         unsigned n_desc_sets;
         int n_pipelines;
         VkPipeline *pipelines;

--- a/vkrunner/vr-test.c
+++ b/vkrunner/vr-test.c
@@ -178,6 +178,9 @@ begin_command_buffer(struct test_data *data)
                 return false;
         }
 
+        data->bound_pipeline = UINT_MAX;
+        data->ubo_descriptor_set_bound = false;
+
         return true;
 }
 
@@ -300,8 +303,6 @@ begin_render_pass(struct test_data *data)
                                    &render_pass_begin_info,
                                    VK_SUBPASS_CONTENTS_INLINE);
 
-        data->bound_pipeline = UINT_MAX;
-        data->ubo_descriptor_set_bound = false;
         data->first_render = false;
 
         return true;

--- a/vkrunner/vr-test.c
+++ b/vkrunner/vr-test.c
@@ -396,8 +396,7 @@ bind_ubo_descriptor_set(struct test_data *data)
                                         context->command_buffer,
                                         VK_PIPELINE_BIND_POINT_GRAPHICS,
                                         data->pipeline->layout,
-                                        /* firstSet */
-                                        data->pipeline->desc_sets[i],
+                                        i, /* firstSet */
                                         1, /* descriptorSetCount */
                                         &data->ubo_descriptor_set[i],
                                         0, /* dynamicOffsetCount */
@@ -411,8 +410,7 @@ bind_ubo_descriptor_set(struct test_data *data)
                                         context->command_buffer,
                                         VK_PIPELINE_BIND_POINT_COMPUTE,
                                         data->pipeline->layout,
-                                        /* firstSet */
-                                        data->pipeline->desc_sets[i],
+                                        i, /* firstSet */
                                         1, /* descriptorSetCount */
                                         &data->ubo_descriptor_set[i],
                                         0, /* dynamicOffsetCount */
@@ -937,8 +935,6 @@ static bool
 allocate_ubo_buffers(struct test_data *data)
 {
         struct vr_vk *vkfn = &data->window->vkfn;
-        unsigned desc_set;
-        unsigned desc_set_index;
 
         VkResult res;
         data->ubo_descriptor_set = vr_alloc(data->pipeline->n_desc_sets *
@@ -965,16 +961,11 @@ allocate_ubo_buffers(struct test_data *data)
         data->ubo_buffers = vr_alloc(sizeof *data->ubo_buffers *
                                      data->script->n_buffers);
 
-        desc_set = data->script->buffers[0].desc_set;
-        desc_set_index = 0;
         for (unsigned i = 0; i < data->script->n_buffers; i++) {
                 const struct vr_script_buffer *script_buffer =
                         data->script->buffers + i;
 
-                if (script_buffer->desc_set != desc_set) {
-                        desc_set = script_buffer->desc_set;
-                        ++desc_set_index;
-                }
+                unsigned desc_set = script_buffer->desc_set;
 
                 enum VkBufferUsageFlagBits usage;
                 VkDescriptorType descriptor_type;
@@ -1007,7 +998,7 @@ allocate_ubo_buffers(struct test_data *data)
                 };
                 VkWriteDescriptorSet write = {
                         .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
-                        .dstSet = data->ubo_descriptor_set[desc_set_index],
+                        .dstSet = data->ubo_descriptor_set[desc_set],
                         .dstBinding = script_buffer->binding,
                         .dstArrayElement = 0,
                         .descriptorCount = 1,


### PR DESCRIPTION
The first patch fixes the bug in issue #44. The second patch is also needed to make the test case from that issue work.

Note however the test case still fails. I think it is written assuming that the test commands use the std430 layout to set data on SSBO. Perhaps that is the case for Amber. VkRunner always std140 for both SSBOs and UBOs (see issue #32) so it doesn’t work. Changing the test to use std140 makes it pass.