### PR TITLE
Support configuring either std140 or std430 layouts for test commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,8 @@ The same as above except that it probes the entire window.
 
 Sets a push constant at the given offset. Note that unlike Piglit, the
 offset is a byte offset into the push constant buffer rather than a
-uniform location. The type can be one of int, uint, int8_t, uint8_t,
-int16_t, uint16_t, int64_t, uint64_t, float, double, vec[234],
-dvec[234], ivec[234], uvec[234], i8vec[234], u8vec[234], i16vec[234],
-u16vec[234], i64vec[234], u64vec[234], mat[234]x[234] or
-dmat[234]x[234]. Multiple values can be specified to upload values to
-an array of that type. If matrices or arrays are specified they are
-assumed to have a stride according to the layout specified with the
-`push layout` command.
+uniform location. For a description of how the arguments work see
+“Setting buffer subdata” below.
 
 > uniform ubo _binding_ _type_ _offset_ _values_…
 
@@ -100,11 +94,11 @@ Sets a value within a uniform buffer. The first time a value is set
 within a buffer it will be created with the minimum size needed to
 contain all of the values set on it via test commands. It will then be
 bound to the descriptor set at the given binding point. The rest of
-the arguments are the same as for the `uniform` command, except that
-the layout is taken from the last `ubo layout` command. Note that the
-buffer is just updated by writing into a memory mapped view of it
-which means that if you do an update, draw call, update and then
-another draw call both draws will use the values from the second
+the arguments are used as described in “Setting buffer subdata” below.
+
+Note that the buffer is just updated by writing into a memory mapped
+view of it which means that if you do an update, draw call, update and
+then another draw call both draws will use the values from the second
 update. This is because the draws are not flushed until the next probe
 command or the test completes.
 
@@ -218,6 +212,85 @@ Sets the entrypoint function to _name_ for the given stage. This will
 be used for subsequent draw calls or compute dispatches.
 
 Take a look in the examples directory for more examples.
+
+## Setting buffer subdata
+
+The commands to set push constants, ubo data and ssbo data all take
+the same three arguments `type`, `offset` and `values…`. These are
+used to describe a chunk of data to store at the given offset in the
+corresponding buffer. The commands can be used multiple times with
+different offsets to set data at different locations.
+
+The type can be one of int, uint, int8_t, uint8_t,
+int16_t, uint16_t, int64_t, uint64_t, float, double, vec[234],
+dvec[234], ivec[234], uvec[234], i8vec[234], u8vec[234], i16vec[234],
+u16vec[234], i64vec[234], u64vec[234], mat[234]x[234] or
+dmat[234]x[234].
+
+The values argument contains one integer or float for each component
+of the given type. Multiple values can be specified in a single
+command to set an array of values of the given type.
+
+Each buffer type (push constant, UBO and SSBO) has a corresponding
+current layout which is either std140 or std430. The current layout
+only matters for matrix types or for specifying array values with a
+single command. It is used to calculate the array stride and matrix
+stride for the given type. The default layouts for each buffer type
+correspond to the defaults for the corresponding buffer type in GLSL.
+Note that the layout is only used as a convenience to set values in
+memory. If you want to use a custom layout it is still always possible
+to set all the values using multiple commands and explicit offsets.
+
+Some examples:
+
+    ssbo 0 subdata float 12  42.0
+
+This will write the float value 42 twelve bytes into the buffer at
+binding 0.
+
+    ssbo layout std140
+    ssbo 0 subdata float 32  1 2 3
+
+This will write the float values 1, 2, 3 into the buffer starting at
+byte 32 arranged such so that it would be suitable for an array of floats
+declared as std140 such as this:
+
+```GLSL
+layout(binding = 0, std140) buffer block {
+   layout(offset = 32) float one_two_three[3];
+};
+```
+
+The rules of std140 force the array stride to be a multiple of a vec4
+so this will effectively write the following floats starting at byte
+32:
+
+```
+1 0 0 0 2 0 0 0 3
+```
+
+```
+ssbo layout std430
+ssbo 0 subdata mat3 12   1 2 3 4 5 6 7 8 9
+```
+
+This will write a mat3 starting at offset 12. std430 treats this like
+an array of 3 vec3s. The stride for vec3s is padded up to vec4 so it
+would write the floats like this:
+
+```
+1 2 3 0 4 5 6 0 7 8 9
+```
+
+```
+ssbo layout std430 row_major
+ssbo 0 subdata mat3 12   1 2 3 4 5 6 7 8 9
+```
+
+This will write the same matrix but laid out in a way suitable for a
+uniform declared as row_major. It will look like this:
+
+    1 4 7 0 2 5 8 0 3 6 9
 
 ## [require] section
 

--- a/README.md
+++ b/README.md
@@ -152,16 +152,21 @@ tolerance. Each tolerance value can be an `double` type real number or
 percentage e.g., `0.01%`. See [examples/tolerance.shader_test](
 examples/tolerance.shader_test) for the usage of `tolerance` command.
 
-> push layout (std140|std430)
+> push layout [std140|std430] [row_major|column_major]
 
-> ssbo layout (std140|std430)
+> ssbo layout [std140|std430] [row_major|column_major]
 
-> ubo layout (std140|std430)
+> ubo layout [std140|std430] [row_major|column_major]
 
 Sets the expected layout for subsequent commands that operate on push
 constants, SSBOs and UBOs respectively. All layouts default to std430
-except the UBO layout which defaults to std140. This matches the
-defaults in GLSL.
+and column_major except the UBO layout which defaults to std140. This
+matches the defaults in GLSL. If row_major or column_major is not
+specified then it will be set back to column_major (ie, it does not
+leave it at as row_major if a previous layout command set it to that).
+Note that setting the matrix major axis only affects the layout of the
+data in memory. The values are still specified in test commands in
+column-major order.
 
 > clear color _r_ _g_ _b_ _a_
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ dvec[234], ivec[234], uvec[234], i8vec[234], u8vec[234], i16vec[234],
 u16vec[234], i64vec[234], u64vec[234], mat[234]x[234] or
 dmat[234]x[234]. Multiple values can be specified to upload values to
 an array of that type. If matrices or arrays are specified they are
-assumed to have a stride according to the std430 layout rules.
+assumed to have a stride according to the layout specified with the
+`push layout` command.
 
 > uniform ubo _binding_ _type_ _offset_ _values_…
 
@@ -100,7 +101,7 @@ within a buffer it will be created with the minimum size needed to
 contain all of the values set on it via test commands. It will then be
 bound to the descriptor set at the given binding point. The rest of
 the arguments are the same as for the `uniform` command, except that
-it values are laid out according to the std140 rules. Note that the
+the layout is taken from the last `ubo layout` command. Note that the
 buffer is just updated by writing into a memory mapped view of it
 which means that if you do an update, draw call, update and then
 another draw call both draws will use the values from the second
@@ -110,8 +111,8 @@ command or the test completes.
 > ssbo _binding_ subdata _type_ _offset_ _values_…
 
 Sets a value within a storage buffer. The command is the same as
-`uniform ubo` except for the different buffer type. The values will be
-laid out according to the std430 rules.
+`uniform ubo` except for the different buffer type. The layout is
+taken from the last `ssbo layout` command.
 
 > ssbo _binding_ _size_
 
@@ -129,8 +130,8 @@ allows errors for `double` or `float` type numbers while `==` does
 not. Allowed errors can be set by the following `tolerance` command.
 See [examples/tolerance.shader_test](examples/tolerance.shader_test)
 for the usage of `~=`. Multiple values can be listed to compare an
-array of values. In that case the buffer is assumed to have std140
-layout.
+array of values. In that case the buffer is assumed to have the layout
+specified with the last `ssbo layout` command.
 
 > tolerance _tolerance0 tolerance1 tolerance2 tolerance3_
 
@@ -150,6 +151,17 @@ components of `vecN` and `matMxN` type values will use the same
 tolerance. Each tolerance value can be an `double` type real number or
 percentage e.g., `0.01%`. See [examples/tolerance.shader_test](
 examples/tolerance.shader_test) for the usage of `tolerance` command.
+
+> push layout (std140|std430)
+
+> ssbo layout (std140|std430)
+
+> ubo layout (std140|std430)
+
+Sets the expected layout for subsequent commands that operate on push
+constants, SSBOs and UBOs respectively. All layouts default to std430
+except the UBO layout which defaults to std140. This matches the
+defaults in GLSL.
 
 > clear color _r_ _g_ _b_ _a_
 

--- a/examples/layouts.shader_test
+++ b/examples/layouts.shader_test
@@ -1,0 +1,75 @@
+[compute shader]
+#version 460
+
+/* Push constants using std140 layout */
+layout(push_constant, std140) uniform push140 {
+        /* input_a[0] will be at offset 0 and input_a[1] will be at 16 */
+        float input_a[2];
+};
+
+/* UBO using std140 (the default) */
+layout(binding = 0) uniform ubo140 {
+        /* input_b[0] will be at offset 0 and input_b[1] will be at 16 */
+        float input_b[2];
+        /* input_c[0] will be at offset 32 and input_c[1] will be at 48 */
+        float input_c[2];
+};
+
+/* SSBO using std430 (the default) */
+layout(binding = 1) buffer ssbo430 {
+        /* output_a[0] will be at offset 0 and output_a[1] will be at 4 */
+        float output_a[2];
+        /* output_b[0] will be at offset 8 and output_b[1] will be at 12 */
+        float output_b[2];
+        /* This will be offset 16 */
+        float constant_a[2];
+};
+
+/* SSBO using std140 */
+layout(binding = 2, std140) buffer ssbo140 {
+        /* output_c[0] will be at offset 0 and output_c[1] will be at 16 */
+        float output_c[2];
+        /* This will be at offset 32 */
+        float constant_b[2];
+};
+
+void
+main()
+{
+        for (int i = 0; i < 2; i++) {
+                output_a[i] = input_a[i];
+                output_b[i] = input_b[i];
+                output_c[i] = input_c[i];
+        }
+}
+
+[test]
+# Set input_a
+push layout std140
+uniform float 0  1.0 2.0
+
+# Set input_b. Layout defaults to std140 so we don’t need to set it,
+# but we set it here anyway as an example.
+ubo layout std140
+uniform ubo 0 float 0  3.0 4.0
+# Set input_c
+uniform ubo 0 float 32  5.0 6.0
+
+# Set constant_a. Layout defaults to std430 so we don’t need to set it
+ssbo 1 subdata float 16  7.0 8.0
+
+# Set constant_b
+ssbo layout std140
+ssbo 2 subdata float 32  9.0 10.0
+
+compute 1 1 1
+
+# Checkout the outputs
+ssbo layout std430
+probe ssbo float 1 0 ~= 1.0 2.0
+probe ssbo float 1 8 ~= 3.0 4.0
+probe ssbo float 1 16 ~= 7.0 8.0
+
+ssbo layout std140
+probe ssbo float 2 0 ~= 5.0 6.0
+probe ssbo float 2 32 ~= 9.0 10.0

--- a/examples/row-major.shader_test
+++ b/examples/row-major.shader_test
@@ -4,27 +4,57 @@
 #version 430
 
 layout (location = 0) out vec4 color_out;
+
 layout (binding = 5) uniform block {
-  layout(row_major) mat3x4 m;
+        layout(column_major) mat3x4 m1;
+        layout(row_major) mat3x4 m2;
+
+        layout(column_major) mat4x3 m3;
+        layout(row_major) mat4x3 m4;
 };
 
 void main()
 {
-   color_out = m[0] + m[1] + m[2];
+        color_out = vec4(0.0, 1.0, 0.0, 1.0);
+
+        /* Check that m1 and m2 have the same value */
+        for (int col = 0; col < 3; col++) {
+                for (int row = 0; row < 4; row++) {
+                        if (m1[col][row] != m2[col][row])
+                                color_out.rg = vec2(1.0, 0.0);
+                }
+        }
+
+        /* Check that m3 and m4 have the same value */
+        for (int col = 0; col < 4; col++) {
+                for (int row = 0; row < 3; row++) {
+                        if (m3[col][row] != m4[col][row])
+                                color_out.rg = vec2(1.0, 0.0);
+                }
+        }
 }
 
 
 [test]
 clear
 
-# The shader uses a mat3x4 that it is specified on row_major
-# layout. So we need to manually re-sort it here when specify the
-# data.
-uniform ubo 5 vec3 0  0.11 0.21 0.31
-uniform ubo 5 vec3 16 0.12 0.22 0.32
-uniform ubo 5 vec3 32 0.13 0.23 0.33
-uniform ubo 5 vec3 48 0.14 0.24 0.34
+# Specify m1 in column major order. This is the default.
+uniform ubo 5 mat3x4 0   1 2 3 4 5 6 7 8 9 10 11 12
+
+# Specify m2 row major order. Note this doesn’t affect the order of
+# the values specified in the test command, only how they are stored
+# in memory.
+ubo layout row_major
+uniform ubo 5 mat3x4 48  1 2 3 4 5 6 7 8 9 10 11 12
+
+# Specify m3 in column major order
+ubo layout column_major
+uniform ubo 5 mat4x3 112 1 2 3 4 5 6 7 8 9 10 11 12
+
+# Specify m4 in row major order
+ubo layout row_major
+uniform ubo 5 mat4x3 176 1 2 3 4 5 6 7 8 9 10 11 12
 
 draw rect -1 -1 2 2
 
-probe all rgba 0.63 0.66 0.69 0.72
+probe all rgba 0.0 1.0 0.0 1.0

--- a/vkrunner/vr-script.c
+++ b/vkrunner/vr-script.c
@@ -902,6 +902,40 @@ parse_fbsize(struct load_state *data,
         return true;
 }
 
+static enum parse_result
+process_layout(struct load_state *data,
+               const char *p)
+{
+        struct vr_box_layout *layout;
+
+        if (looking_at(&p, "push layout "))
+                layout = &data->push_layout;
+        else if (looking_at(&p, "ubo layout "))
+                layout = &data->ubo_layout;
+        else if (looking_at(&p, "ssbo layout "))
+                layout = &data->ssbo_layout;
+        else
+                return PARSE_RESULT_NON_MATCHED;
+
+        if (looking_at(&p, "std140")) {
+                layout->std = VR_BOX_LAYOUT_STD_140;
+        } else if (looking_at(&p, "std430")) {
+                layout->std = VR_BOX_LAYOUT_STD_430;
+        } else {
+                error_at_line(data,
+                              "Expected std140 or std430 "
+                              "in layout command");
+                return PARSE_RESULT_ERROR;
+        }
+
+        if (!is_end(p)) {
+                error_at_line(data, "Trailing data in layout command");
+                return PARSE_RESULT_ERROR;
+        }
+
+        return PARSE_RESULT_OK;
+}
+
 static bool
 process_none_line(struct load_state *data)
 {
@@ -2002,6 +2036,7 @@ process_test_line(struct load_state *data)
         static const process_test_line_func funcs[] = {
                 process_patch_parameter_vertices,
                 process_clear_values,
+                process_layout,
                 process_ssbo_command,
                 process_tolerance,
                 process_entrypoint,


### PR DESCRIPTION
As described in issue #32, this adds commands to set the buffer layouts. The commands are:

```
push layout (std140|std430)
ssbo layout (std140|std430)
ubo layout (std140|std430)
```

Each of them sets the layouts expected for subsequent push constants, SSBOs and UBOs respectively.

There is also a patch to change the defaults for push constants and SSBOs to std430 so that it matches the defaults in GLSL. This makes writing scripts easier. However it also means that existing scripts using SSBOs might break.

Any comments would be appreciated.
