### PR TITLE
Fix Visual Studio 2013 build

### DIFF
--- a/vkrunner/vr-buffer.h
+++ b/vkrunner/vr-buffer.h
@@ -64,7 +64,7 @@ vr_buffer_append(struct vr_buffer *buffer,
                  const void *data,
                  size_t length);
 
-static inline void
+static VR_INLINE void
 vr_buffer_append_c(struct vr_buffer *buffer,
                    char c)
 {

--- a/vkrunner/vr-feature-offsets.c
+++ b/vkrunner/vr-feature-offsets.c
@@ -24,6 +24,7 @@
  */
 
 #include "config.h"
+#include <stddef.h>
 
 #include "vr-feature-offsets.h"
 #include "vr-vk.h"

--- a/vkrunner/vr-list.h
+++ b/vkrunner/vr-list.h
@@ -26,6 +26,7 @@
 #ifndef VR_LIST_H
 #define VR_LIST_H
 
+#include <stddef.h>
 #include "vr-util.h"
 
 /**

--- a/vkrunner/vr-pipeline-key.c
+++ b/vkrunner/vr-pipeline-key.c
@@ -30,6 +30,7 @@
 
 #include <string.h>
 #include <limits.h>
+#include <stddef.h>
 
 static const struct vr_pipeline_key
 base_key = {

--- a/vkrunner/vr-pipeline.c
+++ b/vkrunner/vr-pipeline.c
@@ -34,6 +34,7 @@
 #include "vr-temp-file.h"
 #include "vr-format-private.h"
 
+#include <stddef.h>
 #include <stdio.h>
 #include <errno.h>
 #include <assert.h>

--- a/vkrunner/vr-util.h
+++ b/vkrunner/vr-util.h
@@ -36,6 +36,12 @@
 #include <alloca.h>
 #endif
 
+#ifdef _MSC_VER
+#define VR_INLINE __inline
+#else
+#define VR_INLINE inline
+#endif
+
 #define VR_SWAP_UINT16(x)                       \
   ((uint16_t)                                   \
    (((uint16_t) (x) >> 8) |                     \
@@ -166,7 +172,7 @@ vr_util_ffsl(long int value);
 /**
  * Align a value, only works pot alignemnts.
  */
-static inline int
+static VR_INLINE int
 vr_align(int value, int alignment)
 {
    return (value + alignment - 1) & ~(alignment - 1);

--- a/vkrunner/vr-vk.c
+++ b/vkrunner/vr-vk.c
@@ -32,6 +32,7 @@
 #include <dlfcn.h>
 #endif
 
+#include <stddef.h>
 #include "vr-vk.h"
 #include "vr-util.h"
 #include "vr-error-message.h"


### PR DESCRIPTION
There are issues with inline attribute (not supported on MSVC 2013) and offsetof() (undefined on MSVC 2013). This patch series fixes both.

Checked compilation on MSVC 2013 and GCC (GNU/Linux).