### PR TITLE
vkrunner: Add barriers required for copying an image to the host

### DIFF
--- a/vkrunner/vr-window.c
+++ b/vkrunner/vr-window.c
@@ -2,6 +2,7 @@
  * vkrunner
  *
  * Copyright (C) 2013, 2014, 2015, 2017 Neil Roberts
+ * Copyright (C) 2019 Google LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -234,10 +235,11 @@ create_render_pass(struct vr_window *window,
                         .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
                         .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
                         .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
-                        .initialLayout = (first_render ?
-                                          VK_IMAGE_LAYOUT_UNDEFINED :
-                                          VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL),
-                        .finalLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                        .initialLayout =
+                        (first_render ?
+                         VK_IMAGE_LAYOUT_UNDEFINED :
+                         VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL),
+                        .finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
                 },
                 {
                         .format = (depth_stencil_format ?


### PR DESCRIPTION
Fixes #52 (although some barriers are probably still needed for ssbos).

Note that I have removed the automatic layout transitions for the color attachment and instead opted to keep the color attachment layout as `VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL`. We surround the image copy with `VkImageMemoryBarrier`s to explicitly transition to `VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL` (and back) as well as ensuring sufficient synchronization. A `VkBufferMemoryBarrier` is also added to ensure the host can safely read the data that was copied to the buffer.

This needs careful review from those who have experience with barriers. 