### PR TITLE
vkrunner: Fix typo in set_buffer_subdata

### DIFF
--- a/vkrunner/vr-test.c
+++ b/vkrunner/vr-test.c
@@ -1039,7 +1039,7 @@ set_buffer_subdata(struct test_data *data,
         vr_flush_memory(data->window->context,
                         buffer->memory_type_index,
                         buffer->memory,
-                        command->set_push_constant.offset,
+                        command->set_buffer_subdata.offset,
                         command->set_buffer_subdata.size);
 
         return true;


### PR DESCRIPTION
The offset being passed to vr_flush_memory was being taken from the wrong branch of the command structure.