### PR TITLE
Validate calls to vkFlushMappedMemoryRanges in the build test script

### DIFF
--- a/test-build.sh
+++ b/test-build.sh
@@ -18,6 +18,7 @@ ninja -C "$build_dir" install
 
 # Run the built executable with all of the examples and enable the
 # validation layer. Verify that nothing was written to the output.
+VKRUNNER_ALWAYS_FLUSH_MEMORY=true \
 VK_INSTANCE_LAYERS=VK_LAYER_LUNARG_standard_validation \
                   "$install_dir/bin/vkrunner" \
                   -q \

--- a/vkrunner/vr-context.c
+++ b/vkrunner/vr-context.c
@@ -418,6 +418,9 @@ vr_context_new(const struct vr_config *config,
 
         context->config = config;
 
+        context->always_flush_memory =
+                vr_env_var_as_boolean("VKRUNNER_ALWAYS_FLUSH_MEMORY", false);
+
         vres = init_vk_device(context, requires, extensions);
         if (vres != VR_RESULT_PASS)
                 goto error;

--- a/vkrunner/vr-context.h
+++ b/vkrunner/vr-context.h
@@ -49,6 +49,8 @@ struct vr_context {
         VkInstance vk_instance;
         VkFence vk_fence;
 
+        bool always_flush_memory;
+
         struct vr_vk vkfn;
 };
 

--- a/vkrunner/vr-flush-memory.c
+++ b/vkrunner/vr-flush-memory.c
@@ -40,7 +40,8 @@ vr_flush_memory(struct vr_context *context,
 
         /* We don’t need to do anything if the memory is already
          * coherent */
-        if ((memory_type->propertyFlags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT))
+        if (!context->always_flush_memory &&
+            (memory_type->propertyFlags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT))
                 return VK_SUCCESS;
 
         VkMappedMemoryRange mapped_memory_range = {

--- a/vkrunner/vr-util.c
+++ b/vkrunner/vr-util.c
@@ -2,6 +2,7 @@
  * vkrunner
  *
  * Copyright (C) 2013, 2014 Neil Roberts
+ * Copyright © 2015 Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -162,6 +163,32 @@ vr_free(void *ptr)
 {
         if (ptr)
                 free(ptr);
+}
+
+/**
+ * Reads an environment variable and interprets its value as a boolean.
+ *
+ * Recognizes 0/false/no and 1/true/yes. Other values result in the
+ * default value.
+ */
+bool
+vr_env_var_as_boolean(const char *var_name, bool default_value)
+{
+        const char *str = getenv(var_name);
+        if (str == NULL)
+                return default_value;
+
+        if (strcmp(str, "1") == 0 ||
+            strcasecmp(str, "true") == 0 ||
+            strcasecmp(str, "yes") == 0) {
+                return true;
+        } else if (strcmp(str, "0") == 0 ||
+                   strcasecmp(str, "false") == 0 ||
+                   strcasecmp(str, "no") == 0) {
+                return false;
+        } else {
+                return default_value;
+        }
 }
 
 #ifndef HAVE_FFS

--- a/vkrunner/vr-util.h
+++ b/vkrunner/vr-util.h
@@ -28,6 +28,7 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 /* Include the right header for alloca */
 #ifdef WIN32
@@ -141,6 +142,9 @@ vr_strconcat(const char *string1, ...);
 
 void
 vr_free(void *ptr);
+
+bool
+vr_env_var_as_boolean(const char *var_name, bool default_value);
 
 VR_NO_RETURN
 VR_PRINTF_FORMAT(1, 2)


### PR DESCRIPTION
In PR #54 it was reported that the offset and size used in vkFlushMappedMemoryRanges was wrong and the validation layers were reporting it. This function is only called on platforms where the memory type is incoherent so on my Intel development machine the test build script wasn’t catching it. In order to avoid this situation regressing, this patch adds a debug environment variable to make it call vkFlushMappedMemoryRanges even when the memory is coherent. The test-build script then sets it so that the parameters to the flush command will be seen by the validation layers.