### PR TITLE
Add float16 types

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -44,6 +44,7 @@ VKRUNNER_SRC_FILES := vkrunner/vr-allocate-store.c \
 	vkrunner/vr-requirements.c \
 	vkrunner/vr-result.c \
 	vkrunner/vr-script.c \
+	vkrunner/vr-small-float.c \
 	vkrunner/vr-source.c \
 	vkrunner/vr-stream.c \
 	vkrunner/vr-strtof.c \

--- a/README.md
+++ b/README.md
@@ -86,12 +86,13 @@ The same as above except that it probes the entire window.
 Sets a push constant at the given offset. Note that unlike Piglit, the
 offset is a byte offset into the push constant buffer rather than a
 uniform location. The type can be one of int, uint, int8_t, uint8_t,
-int16_t, uint16_t, int64_t, uint64_t, float, double, vec[234],
-dvec[234], ivec[234], uvec[234], i8vec[234], u8vec[234], i16vec[234],
-u16vec[234], i64vec[234], u64vec[234], mat[234]x[234] or
-dmat[234]x[234]. Multiple values can be specified to upload values to
-an array of that type. If matrices or arrays are specified they are
-assumed to have a stride according to the std430 layout rules.
+int16_t, uint16_t, int64_t, uint64_t, float16_t, float, double,
+f16vec[234], vec[234], dvec[234], ivec[234], uvec[234], i8vec[234],
+u8vec[234], i16vec[234], u16vec[234], i64vec[234], u64vec[234],
+mat[234]x[234] or dmat[234]x[234]. Multiple values can be specified to
+upload values to an array of that type. If matrices or arrays are
+specified they are assumed to have a stride according to the std430
+layout rules.
 
 > (ubo|ssbo) _binding_ subdata _type_ _offset_ _values_…
 

--- a/vkrunner/CMakeLists.txt
+++ b/vkrunner/CMakeLists.txt
@@ -52,6 +52,8 @@ set(VKRUNNER_SOURCE_FILES
         vr-result.c
         vr-script.c
         vr-script-private.h
+        vr-small-float.c
+        vr-small-float.h
         vr-source-private.h
         vr-source.c
         vr-stream.c

--- a/vkrunner/vr-box.c
+++ b/vkrunner/vr-box.c
@@ -31,6 +31,7 @@
 
 #include "vr-util.h"
 #include "vr-tolerance.h"
+#include "vr-half-float.h"
 
 static const struct vr_box_type_info
 type_infos[] = {
@@ -42,8 +43,12 @@ type_infos[] = {
         [VR_BOX_TYPE_UINT16] = { VR_BOX_BASE_TYPE_UINT16, 1, 1 },
         [VR_BOX_TYPE_INT64] = { VR_BOX_BASE_TYPE_INT64, 1, 1 },
         [VR_BOX_TYPE_UINT64] = { VR_BOX_BASE_TYPE_UINT64, 1, 1 },
+        [VR_BOX_TYPE_FLOAT16] = { VR_BOX_BASE_TYPE_FLOAT16, 1, 1 },
         [VR_BOX_TYPE_FLOAT] = { VR_BOX_BASE_TYPE_FLOAT, 1, 1 },
         [VR_BOX_TYPE_DOUBLE] = { VR_BOX_BASE_TYPE_DOUBLE, 1, 1 },
+        [VR_BOX_TYPE_F16VEC2] = { VR_BOX_BASE_TYPE_FLOAT16, 1, 2 },
+        [VR_BOX_TYPE_F16VEC3] = { VR_BOX_BASE_TYPE_FLOAT16, 1, 3 },
+        [VR_BOX_TYPE_F16VEC4] = { VR_BOX_BASE_TYPE_FLOAT16, 1, 4 },
         [VR_BOX_TYPE_VEC2] = { VR_BOX_BASE_TYPE_FLOAT, 1, 2 },
         [VR_BOX_TYPE_VEC3] = { VR_BOX_BASE_TYPE_FLOAT, 1, 3 },
         [VR_BOX_TYPE_VEC4] = { VR_BOX_BASE_TYPE_FLOAT, 1, 4 },
@@ -106,6 +111,7 @@ vr_box_base_type_size(enum vr_box_base_type type)
         case VR_BOX_BASE_TYPE_UINT16: return sizeof (uint16_t);
         case VR_BOX_BASE_TYPE_INT64: return sizeof (int64_t);
         case VR_BOX_BASE_TYPE_UINT64: return sizeof (uint64_t);
+        case VR_BOX_BASE_TYPE_FLOAT16: return sizeof (uint16_t);
         case VR_BOX_BASE_TYPE_FLOAT: return sizeof (float);
         case VR_BOX_BASE_TYPE_DOUBLE: return sizeof (double);
         }
@@ -368,6 +374,13 @@ compare_value(const struct compare_closure *data,
                 return compare_unsigned(data->comparison,
                                         *(const uint64_t *) a,
                                         *(const uint64_t *) b);
+        case VR_BOX_BASE_TYPE_FLOAT16: {
+                uint16_t ai = *(const uint16_t *) a;
+                uint16_t bi = *(const uint16_t *) b;
+                return compare_double(data,
+                                      vr_half_float_to_double(ai),
+                                      vr_half_float_to_double(bi));
+        }
         case VR_BOX_BASE_TYPE_FLOAT:
                 return compare_double(data,
                                       *(const float *) a,

--- a/vkrunner/vr-box.h
+++ b/vkrunner/vr-box.h
@@ -56,8 +56,12 @@ enum vr_box_type {
         VR_BOX_TYPE_UINT16,
         VR_BOX_TYPE_INT64,
         VR_BOX_TYPE_UINT64,
+        VR_BOX_TYPE_FLOAT16,
         VR_BOX_TYPE_FLOAT,
         VR_BOX_TYPE_DOUBLE,
+        VR_BOX_TYPE_F16VEC2,
+        VR_BOX_TYPE_F16VEC3,
+        VR_BOX_TYPE_F16VEC4,
         VR_BOX_TYPE_VEC2,
         VR_BOX_TYPE_VEC3,
         VR_BOX_TYPE_VEC4,
@@ -117,6 +121,7 @@ enum vr_box_base_type {
         VR_BOX_BASE_TYPE_UINT16,
         VR_BOX_BASE_TYPE_INT64,
         VR_BOX_BASE_TYPE_UINT64,
+        VR_BOX_BASE_TYPE_FLOAT16,
         VR_BOX_BASE_TYPE_FLOAT,
         VR_BOX_BASE_TYPE_DOUBLE
 };

--- a/vkrunner/vr-half-float.c
+++ b/vkrunner/vr-half-float.c
@@ -24,6 +24,7 @@
 #include "config.h"
 
 #include "vr-half-float.h"
+#include "vr-small-float.h"
 
 union fi_type {
         float f;
@@ -115,4 +116,10 @@ vr_half_float_from_float(float val)
 
         result = (s << 15) | (e << 10) | m;
         return result;
+}
+
+double
+vr_half_float_to_double(uint16_t half)
+{
+        return vr_small_float_load_signed(half, 5, 10);
 }

--- a/vkrunner/vr-half-float.h
+++ b/vkrunner/vr-half-float.h
@@ -31,4 +31,7 @@
 uint16_t
 vr_half_float_from_float(float val);
 
+double
+vr_half_float_to_double(uint16_t half);
+
 #endif /* VR_HALF_FLOAT_H */

--- a/vkrunner/vr-small-float.c
+++ b/vkrunner/vr-small-float.c
@@ -1,0 +1,62 @@
+/*
+ * vkrunner
+ *
+ * Copyright (C) 2018, 2019 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "config.h"
+
+#include "vr-small-float.h"
+
+double
+vr_small_float_load_unsigned(uint32_t part,
+                             int e_bits,
+                             int m_bits)
+{
+        int e_max = UINT32_MAX >> (32 - e_bits);
+        int e = (part >> m_bits) & e_max;
+        int m = part & (UINT32_MAX >> (32 - m_bits));
+
+        if (e == e_max)
+                return m == 0 ? INFINITY : NAN;
+
+        if (e == 0)
+                e = 1;
+        else
+                m += 1 << m_bits;
+
+        return ldexp(m / (double) (1 << m_bits), e - (e_max >> 1));
+}
+
+double
+vr_small_float_load_signed(uint32_t part,
+                           int e_bits,
+                           int m_bits)
+{
+        double res = vr_small_float_load_unsigned(part, e_bits, m_bits);
+
+        if (res != NAN && (part & (1 << (e_bits + m_bits))))
+                res = -res;
+
+        return res;
+}
+

--- a/vkrunner/vr-small-float.h
+++ b/vkrunner/vr-small-float.h
@@ -1,0 +1,45 @@
+/*
+ * vkrunner
+ *
+ * Copyright (C) 2019 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef VR_SMALL_FLOAT_H
+#define VR_SMALL_FLOAT_H
+
+#include "vr-small-float.h"
+
+#include <stdint.h>
+#include <math.h>
+#include <inttypes.h>
+
+double
+vr_small_float_load_unsigned(uint32_t part,
+                             int e_bits,
+                             int m_bits);
+
+double
+vr_small_float_load_signed(uint32_t part,
+                           int e_bits,
+                           int m_bits);
+
+#endif /* VR_SMALL_FLOAT_H */

--- a/vkrunner/vr-test.c
+++ b/vkrunner/vr-test.c
@@ -36,6 +36,7 @@
 #include "vr-buffer.h"
 #include "vr-format-private.h"
 #include "vr-tolerance.h"
+#include "vr-half-float.h"
 
 #include <math.h>
 #include <stdio.h>
@@ -978,6 +979,11 @@ append_box_cb(enum vr_box_base_type base_type,
                                         "%" PRIu64,
                                         *(const uint64_t *) p);
                 break;
+        case VR_BOX_BASE_TYPE_FLOAT16: {
+                double v = vr_half_float_to_double(*(const uint16_t *) p);
+                vr_buffer_append_printf(data->buf, "%f", v);
+                break;
+        }
         case VR_BOX_BASE_TYPE_FLOAT:
                 vr_buffer_append_printf(data->buf, "%f", *(const float *) p);
                 break;


### PR DESCRIPTION
Adds float16 types for setting values in uniforms and SSBOs as well as for probing SSBOs.