### PR TITLE
Allow selecting the Vulkan device

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,10 +416,11 @@ ubo 0 subdata int 0 \
     Runs the shader test script SCRIPT
     
     Options:
-      -h            Show this help message
-      -i IMG        Write the final rendering to IMG as a PPM image
-      -d            Show the SPIR-V disassembly
-      -D TOK=REPL   Replace occurences of TOK with REPL in the scripts
+      -h                Show this help message
+      -i IMG            Write the final rendering to IMG as a PPM image
+      -d                Show the SPIR-V disassembly
+      -D TOK=REPL       Replace occurences of TOK with REPL in the scripts
+      --device-id DEVID Select the Vulkan device
 
 ## Precompiling shaders
 

--- a/test-build.sh
+++ b/test-build.sh
@@ -5,6 +5,15 @@ set -eu
 src_dir="$(cd $(dirname "$0") && pwd)"
 build_dir="$src_dir/tmp-build"
 install_dir="$build_dir/install"
+device_id=""
+
+if [ $# -gt 0 ] && [ "$1" = "--device-id" ]; then
+    if [ -z "${2:-}" ]; then
+        echo "--device-id must be followed by a number"
+        exit 1
+    fi
+    device_id="--device-id $2"
+fi
 
 rm -fr -- "$build_dir"
 
@@ -34,7 +43,7 @@ fi
 # Try again with precompiled scripts
 "$src_dir"/precompile-script.py -o "$build_dir/precompiled-examples" \
           "$src_dir/examples"/*.shader_test
-"$install_dir/bin/vkrunner" \
+"$install_dir/bin/vkrunner" $device_id \
     "$build_dir/precompiled-examples/"*.shader_test
 
 # Extract the example from the README. This will test both that the

--- a/vkrunner/vr-config-private.h
+++ b/vkrunner/vr-config-private.h
@@ -33,6 +33,7 @@
 
 struct vr_config {
         bool show_disassembly;
+        int device_id;
 
         vr_callback_error error_cb;
         vr_callback_inspect inspect_cb;

--- a/vkrunner/vr-config.c
+++ b/vkrunner/vr-config.c
@@ -32,6 +32,7 @@ vr_config_new(void)
 {
         struct vr_config *config = vr_calloc(sizeof(struct vr_config));
         vr_strtof_init(&config->strtof_data);
+        config->device_id = -1;
         return config;
 }
 
@@ -69,4 +70,11 @@ vr_config_set_inspect_cb(struct vr_config *config,
                          vr_callback_inspect inspect_cb)
 {
         config->inspect_cb = inspect_cb;
+}
+
+void
+vr_config_set_device_id(struct vr_config *config,
+                        int device_id)
+{
+        config->device_id = device_id;
 }

--- a/vkrunner/vr-config.h
+++ b/vkrunner/vr-config.h
@@ -71,6 +71,10 @@ void
 vr_config_set_inspect_cb(struct vr_config *config,
                          vr_callback_inspect inspect_cb);
 
+void
+vr_config_set_device_id(struct vr_config *config,
+                        int device_id);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/vkrunner/vr-context.c
+++ b/vkrunner/vr-context.c
@@ -30,6 +30,7 @@
 #include <assert.h>
 #include <string.h>
 
+#include "vr-config-private.h"
 #include "vr-context.h"
 #include "vr-util.h"
 #include "vr-error-message.h"
@@ -137,7 +138,19 @@ find_physical_device(struct vr_context *context,
                 return VR_RESULT_FAIL;
         }
 
-        for (i = 0; i < count; i++) {
+        int dev_id = context->config->device_id;
+        int first_dev = 0;
+        if (dev_id >= 0) {
+                if (dev_id >= count) {
+                        vr_error_message(context->config,
+                                         "Error unsupported device id.");
+                        return VR_RESULT_SKIP;
+                }
+
+                first_dev = dev_id;
+                count = first_dev + 1;
+        }
+        for (i = first_dev; i < count; i++) {
                 if (!vr_requirements_check(reqs,
                                            vkfn,
                                            context->vk_instance,


### PR DESCRIPTION
Users can select the Vulkan device using the option --device-id like follows:

`./vkrunner --device-id <device number>`
or
`./vkrunner --device-id=<device number>`