### PR TITLE
Change the default Vulkan API patch version to 0

### DIFF
--- a/vkrunner/vr-requirements.c
+++ b/vkrunner/vr-requirements.c
@@ -63,7 +63,7 @@ vr_requirements_new(void)
         vr_buffer_init(&reqs->extensions);
         vr_list_init(&reqs->structures);
 
-        reqs->version = VK_MAKE_VERSION(1, 0, 2);
+        reqs->version = VK_MAKE_VERSION(1, 0, 0);
 
         return reqs;
 }


### PR DESCRIPTION
Previously the default patch version was 2. According to the Vulkan
spec, all versions that only differ by the patch version are
compatible with each other so there is no reason to require any
particular patch version. (See 29.6.1 of the 1.0 spec).

The main incentive to do this is that there is a dummy ICD for testing
in the Vulkan-Tools repo and that reports an API version of 1.0.0.
Without this patch VkRunner refuses to work with that driver.