### PR TITLE
Report 'skip' on instance creation failure.

### DIFF
--- a/vkrunner/vr-context.c
+++ b/vkrunner/vr-context.c
@@ -262,7 +262,7 @@ init_vk_device(struct vr_context *context,
         if (res != VK_SUCCESS) {
                 vr_error_message(context->config,
                                  "Failed to create VkInstance");
-                return VR_RESULT_FAIL;
+                return VR_RESULT_SKIP;
         }
 
         vr_vk_init_instance(vkfn, get_instance_proc, context);


### PR DESCRIPTION
This causes vkrunner tests to report 'skip' rather than 'fail' when
run on a platform which doesn't support Vulkan and has no drivers.
The tests aren't running and failing - they're simply not executing.

For example, a CI system might deploy piglit and vkrunner on all
systems, but only some machines support Vulkan.  Similarly, Piglit
builds all OpenGL tests, but if the GPU doesn't support the required
API, then tests report 'skip'.