### PR TITLE
Report 'skip' on instance creation failure.

### DIFF
--- a/vkrunner/vr-context.c
+++ b/vkrunner/vr-context.c
@@ -262,7 +262,15 @@ init_vk_device(struct vr_context *context,
         if (res != VK_SUCCESS) {
                 vr_error_message(context->config,
                                  "Failed to create VkInstance");
-                return VR_RESULT_FAIL;
+                if (res == VK_ERROR_INCOMPATIBLE_DRIVER) {
+                        /* The loader reports this if there are no
+                         * drivers available at all. In that case we
+                         * want to skip.
+                         */
+                        return VR_RESULT_SKIP;
+                } else {
+                        return VR_RESULT_FAIL;
+                }
         }
 
         vr_vk_init_instance(vkfn, get_instance_proc, context);


### PR DESCRIPTION
(This is a v2 of [MR#67](https://github.com/Igalia/vkrunner/pull/67))

This causes vkrunner tests to report 'skip' rather than 'fail' when
run on a platform which doesn't support Vulkan and has no drivers.
The tests aren't running and failing - they're simply not executing.

For example, a CI system might deploy piglit and vkrunner on all
systems, but only some machines support Vulkan.  Similarly, Piglit
builds all OpenGL tests, but if the GPU doesn't support the required
API, then tests report 'skip'.

v2: Only report skip if the error code is VK_ERROR_INCOMPATIBLE_DRIVER.
    (Neil Roberts)