### PR TITLE
CmakeLists: fix install libdir bindir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.0.2)
 
 include(TestBigEndian)
 include(CheckLibraryExists)
@@ -7,7 +7,7 @@ include(CheckCCompilerFlag)
 include(FindPkgConfig)
 include(CheckIncludeFile)
 
-project(VkRunner)
+project(VkRunner LANGUAGES C)
 set(VKRUNNER_VERSION 0.1)
 
 TEST_BIG_ENDIAN(IS_BIG_ENDIAN)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,4 +12,4 @@ set_target_properties(vkrunnerbin PROPERTIES OUTPUT_NAME "vkrunner")
 
 target_link_libraries(vkrunnerbin vkrunner)
 
-install(TARGETS vkrunnerbin DESTINATION bin)
+install(TARGETS vkrunnerbin DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/test-build.sh
+++ b/test-build.sh
@@ -57,7 +57,7 @@ sed -rn -e '/^```C\s*$/,/^```\s*$/! b ; s/^```.*// ; p' \
     < "$src_dir/README.md" \
     > "$example_dir/myrunner.c"
 
-export PKG_CONFIG_PATH="$install_dir/lib/pkgconfig"
+export PKG_CONFIG_PATH=$(find "$install_dir" -name pkgconfig)
 
 gcc -Wall -Werror -o "$example_dir/myrunner" "$example_dir/myrunner.c" \
     $(pkg-config vkrunner --cflags --libs)

--- a/vkrunner/CMakeLists.txt
+++ b/vkrunner/CMakeLists.txt
@@ -1,5 +1,7 @@
 # cmake file for VkRunner
 
+include(GNUInstallDirs)
+
 include_directories(${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR})
 
 set(VKRUNNER_PUBLIC_HEADERS

--- a/vkrunner/CMakeLists.txt
+++ b/vkrunner/CMakeLists.txt
@@ -104,7 +104,7 @@ endif()
 include_directories(${VULKAN_INCLUDE_DIRS})
 add_definitions(${VULKAN_CFLAGS_OTHER})
 
-install(TARGETS vkrunner DESTINATION lib)
+install(TARGETS vkrunner DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(FILES ${VKRUNNER_PUBLIC_HEADERS} DESTINATION include/vkrunner)
 
 configure_file(
@@ -113,4 +113,4 @@ configure_file(
   @ONLY
   )
 install(FILES "${PROJECT_BINARY_DIR}/vkrunner/vkrunner.pc"
-  DESTINATION lib/pkgconfig)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/vkrunner/vkrunner.pc.in
+++ b/vkrunner/vkrunner.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/lib
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: libvkrunner


### PR DESCRIPTION
Previously it was fixed to <path>/lib but some distros install 64-bit
libraries in <path>/lib64.

Fixed bindir as well.

Signed-off-by: Samuel Iglesias Gonsálvez <siglesias@igalia.com>