### PR TITLE
box: Don’t apply the major axis setting to vector types

### DIFF
--- a/vkrunner/vr-box.c
+++ b/vkrunner/vr-box.c
@@ -119,6 +119,17 @@ vr_box_base_type_size(enum vr_box_base_type type)
         vr_fatal("Unknown base type");
 }
 
+static enum vr_box_major_axis
+get_effective_major_axis(const struct vr_box_type_info *info,
+                         const struct vr_box_layout *layout)
+{
+        /* The major axis setting only affects matrix types */
+        if (info->columns > 1)
+                return layout->major;
+        else
+                return VR_BOX_MAJOR_AXIS_COLUMN;
+}
+
 static void
 get_major_minor(enum vr_box_type type,
                 const struct vr_box_layout *layout,
@@ -127,7 +138,7 @@ get_major_minor(enum vr_box_type type,
 {
         const struct vr_box_type_info *info = type_infos + type;
 
-        switch (layout->major) {
+        switch (get_effective_major_axis(info, layout)) {
         case VR_BOX_MAJOR_AXIS_COLUMN:
                 *major = info->columns;
                 *minor = info->rows;
@@ -210,7 +221,7 @@ get_axis_offsets(enum vr_box_type type,
         size_t stride = vr_box_type_matrix_stride(type, layout);
         size_t base_size = vr_box_base_type_size(info->base_type);
 
-        switch (layout->major) {
+        switch (get_effective_major_axis(info, layout)) {
         case VR_BOX_MAJOR_AXIS_COLUMN:
                 *column_offset = stride - base_size * info->rows;
                 *row_offset = base_size;


### PR DESCRIPTION
The major axis setting should only affect matrix types. Previously if a test script changed the layout to row-major in order to set up some matrix values and then also set up some vec values then the vec values would be stored incorrectly.

I don’t have commit access to the repo so if you think this patch is ok please merge it. Thanks!

I noticed this while working on a [port to rust](https://github.com/bpeel/vkrunner/commits/rust).