### PR TITLE
Use vr_strcasecmp for Windows compatibility

### DIFF
--- a/vkrunner/vr-util.c
+++ b/vkrunner/vr-util.c
@@ -179,12 +179,12 @@ vr_env_var_as_boolean(const char *var_name, bool default_value)
                 return default_value;
 
         if (strcmp(str, "1") == 0 ||
-            strcasecmp(str, "true") == 0 ||
-            strcasecmp(str, "yes") == 0) {
+            vr_strcasecmp(str, "true") == 0 ||
+            vr_strcasecmp(str, "yes") == 0) {
                 return true;
         } else if (strcmp(str, "0") == 0 ||
-                   strcasecmp(str, "false") == 0 ||
-                   strcasecmp(str, "no") == 0) {
+                   vr_strcasecmp(str, "false") == 0 ||
+                   vr_strcasecmp(str, "no") == 0) {
                 return false;
         } else {
                 return default_value;


### PR DESCRIPTION
The `vr-util.h` has a preprocessor definition for `vr_strcasecmp` that selects the correct case-insensitive string comparison function for the current operating system.
However, `vr-util.c` contains uses of `strcasecmp` instead of `vr_strcasecmp`, which causes compilation to fail on Windows.